### PR TITLE
feat: link manifest and register service worker

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Roll-et</title>
     <meta name="theme-color" content="#0ea5e9" />
+    <link rel="manifest" href="/roll-et/manifest.webmanifest">
     <script>
       // SPA deep-link restore when 404.html bounced us here
       (function(){
@@ -23,5 +24,9 @@
     <div id="root"></div>
     <!-- IMPORTANT: entry must be /src/main.tsx for Vite build; do NOT prefix with /roll-et -->
     <script type="module" src="/src/main.tsx"></script>
+    <script type="module">
+      import { registerSW } from "virtual:pwa-register";
+      registerSW();
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- link PWA manifest to page head
- register service worker at startup

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a652c710108322ba2a16ff256d1dff