### PR TITLE
chore: add standard Node/TypeScript gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,27 @@
+# Dependencies
+node_modules/
+
+# Build output
+dist/
+build/
+
+# Test coverage
+coverage/
+
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# Environment files
+.env
+.env.*.local
+
+# TypeScript cache
+*.tsbuildinfo
+
+# Misc
+.DS_Store


### PR DESCRIPTION
## Summary
- add .gitignore to exclude dependencies, build output, logs, coverage, and environment files

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a70dd1c3ec8322ab2a5f56ce4cdee0