### PR TITLE
refactor: modularize game sections with components and hooks

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,31 +1,16 @@
 import React from 'react'
-import { Link } from 'react-router-dom'
-import { BetGrid } from './components/BetGrid'
-import { Bet, BetType, OddsTable, makeQuarterFromAnchor, resolveRound, numberGrid } from './game/engine'
+import { BetBoard } from './components/BetBoard'
+import { BetControls } from './components/BetControls'
+import { HistorySection } from './components/HistorySection'
+import { FooterBar } from './components/FooterBar'
+import { Bet, OddsTable, makeQuarterFromAnchor, resolveRound, numberGrid } from './game/engine'
 import { useInstallPrompt } from './pwa/useInstallPrompt'
+import type { BetMode, Player, RoundState } from './types'
+import { clampInt, fmtUSD, fmtUSDSign } from './utils'
+import { useBetActions } from './hooks/useBetActions'
 
 const MIN_BET = 1
 const PER_ROUND_POOL = 8
-const CREDIT_VALUE = 0.25
-
-type BetMode =
-  | { kind: 'single' }
-  | { kind: 'split'; first?: number }
-  | { kind: 'quarter' }
-  | { kind: 'high' }
-  | { kind: 'low' }
-  | { kind: 'even' }
-  | { kind: 'odd' }
-
-type RoundState = 'open' | 'locked' | 'settled'
-
-interface Player {
-  id: number
-  name: string
-  bets: Bet[]
-  pool: number
-  bank: number
-}
 
 export default function App() {
   const playersInit: Player[] = React.useMemo(() => (
@@ -88,32 +73,13 @@ export default function App() {
     return s
   }, [players])
 
-  const addBetFor = (pid: number, bet: Omit<Bet, 'id'>) => {
-    setPlayers(prev => prev.map(p => {
-      if(p.id !== pid) return p
-      if(!canPlace(p)) return p
-      const id = String(Date.now()) + '-' + Math.random().toString(36).slice(2,7)
-      return { ...p, bets: [...p.bets, { ...bet, id }], pool: p.pool - bet.amount }
-    }))
-  }
-
-  const undoLast = (pid: number) => {
-    if(roundState!=='open') return
-    setPlayers(prev => prev.map(p => {
-      if(p.id !== pid) return p
-      const last = p.bets[p.bets.length-1]
-      if(!last) return p
-      const bets = p.bets.slice(0, -1)
-      return { ...p, bets, pool: p.pool + last.amount }
-    }))
-    if((mode as any).kind==='split' && (mode as any).first){ setMode({kind:'split'}) }
-  }
-
-  const clearBets = (pid: number) => {
-    if(roundState!=='open') return
-    setPlayers(prev => prev.map(p => p.id===pid ? ({ ...p, pool: PER_ROUND_POOL, bets: [] }) : p))
-    if((mode as any).kind==='split' && (mode as any).first){ setMode({kind:'split'}) }
-  }
+  const { addBetFor, undoLast, clearBets } = useBetActions({
+    roundState,
+    setPlayers,
+    mode,
+    setMode,
+    perRoundPool: PER_ROUND_POOL,
+  })
 
   const onCellClick = (n: number) => {
     if(roundState!=='open') return
@@ -214,11 +180,11 @@ export default function App() {
       <header className="header">
         <div className="left" />
         <h1>Roll-et</h1>
-          <div className="right">
-            <div className="credits">
-              Round: <span className={`roundstate ${roundState}`}>{roundState.toUpperCase()}</span>
-            </div>
+        <div className="right">
+          <div className="credits">
+            Round: <span className={`roundstate ${roundState}`}>{roundState.toUpperCase()}</span>
           </div>
+        </div>
       </header>
 
       {isiOS && !installed && (
@@ -236,63 +202,32 @@ export default function App() {
         ))}
       </section>
 
-      <section className="controls">
-        <div className="amount">
-          <label>Bet: </label>
-          <input
-            type="number" min={MIN_BET} max={maxForActive} step={1}
-            value={amount}
-            onChange={(e)=> setAmount(clampInt(e.target.valueAsNumber || MIN_BET, MIN_BET, maxForActive))}
-            disabled={active.pool === 0}
-          />
-          <span className="hint">(min {MIN_BET}, remaining pool {active.pool})</span>
-          <span className="active-name">Active: {players.find(p=>p.id===activePid)?.name}</span>
-        </div>
+      <BetControls
+        amount={amount}
+        setAmount={setAmount}
+        minBet={MIN_BET}
+        maxForActive={maxForActive}
+        active={active}
+        mode={mode}
+        setMode={setMode}
+        roundState={roundState}
+        undoLast={undoLast}
+        clearBets={clearBets}
+        lockRound={lockRound}
+        enteredRoll={enteredRoll}
+        setEnteredRoll={setEnteredRoll}
+        settleRound={settleRound}
+        newRound={newRound}
+      />
 
-        <div className="betmodes">
-          {(['single','split','quarter','even','odd','high','low'] as BetType[]).map(k => (
-            <button
-              key={k}
-              className={(mode as any).kind === k ? 'active' : ''}
-              onClick={()=> setMode(k==='split' ? {kind:'split'} : {kind: k as any})}
-              disabled={roundState!=='open' || !canPlace(players.find(p=>p.id===activePid)!)}>
-              {labelFor(k as any)}
-            </button>
-          ))}
-        </div>
-
-        <div className="actions">
-          <button onClick={()=>undoLast(activePid)} disabled={roundState!=='open' || players.find(p=>p.id===activePid)!.bets.length===0}>Undo</button>
-          <button onClick={()=>clearBets(activePid)} disabled={roundState!=='open' || players.find(p=>p.id===activePid)!.bets.length===0}>Clear</button>
-          <button onClick={lockRound} disabled={roundState!=='open'}>Lock Bets</button>
-          <div className="manual-roll">
-            <input
-              type="number" min={1} max={20} placeholder="roll 1–20"
-              value={enteredRoll}
-              onChange={e=> setEnteredRoll((() => {
-                const v = e.target.valueAsNumber
-                if(!Number.isFinite(v)) return '' as const
-                const n = clampInt(v, 1, 20)
-                return n as unknown as number
-              })())}
-              disabled={roundState!=='locked'}
-            />
-            <button onClick={settleRound} disabled={roundState!=='locked' || !enteredRoll}>Settle</button>
-            <button onClick={newRound} disabled={roundState!=='settled'}>New Round</button>
-          </div>
-        </div>
-      </section>
-
-      <section className="table-wrap">
-        <BetGrid
-          grid={numberGrid}
-          mode={(mode as any).kind}
-          onCellClick={onCellClick}
-          splitFirst={(mode as any).kind==='split' ? (mode as any).first : undefined}
-          covered={covered}
-          winning={winning}
-        />
-      </section>
+      <BetBoard
+        grid={numberGrid}
+        mode={(mode as any).kind}
+        onCellClick={onCellClick}
+        splitFirst={(mode as any).kind==='split' ? (mode as any).first : undefined}
+        covered={covered}
+        winning={winning}
+      />
 
       <section className="bets">
         <h3>{players.find(p=>p.id===activePid)?.name} Bets (potential payout)</h3>
@@ -303,71 +238,18 @@ export default function App() {
                 <span>{describeBet(b)}</span>
                 <span> × {b.amount} → </span>
                 <span className="muted">{b.odds}:1</span>
-                <span> =&nbsp;<strong>{fmtUSD(b.amount * b.odds)}</strong></span>
+                <span> =&nbsp;<strong>{fmtUSD(potential(b))}</strong></span>
               </li>
             ))}
           </ul>
         )}
       </section>
 
-      <section className="history">
-        <h3>History</h3>
-        {history.length===0 ? <div className="muted">No rounds yet.</div> : (
-          <table>
-            <thead>
-              <tr>
-                <th>Roll</th>
-                {players.map(p=> <th key={p.id}>{p.name} Δ</th>)}
-                <th>Time</th>
-              </tr>
-            </thead>
-            <tbody>
-              {history.map((h,i)=>(
-                <tr key={i}>
-                  <td>{h.roll}</td>
-                  {players.map(p => {
-                    const d = h.deltas[p.id] ?? 0
-                    const cls = d>=0 ? 'pos' : 'neg'
-                    return <td key={p.id} className={cls}>{fmtUSDSign(d)}</td>
-                  })}
-                  <td>{new Date(h.time).toLocaleTimeString()}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        )}
-      </section>
+      <HistorySection history={history} players={players} fmtUSDSign={fmtUSDSign} />
 
-      <footer className="footer-bar">
-        <div className="left">
-          {canInstall && <button className="install-btn" onClick={install}>Install</button>}
-          {installed && <span className="installed">Installed</span>}
-        </div>
-        <div className="center">© Kraken Consulting, LLC (Dev Team)</div>
-        <div className="right">
-          <Link className="link-btn" to="/stats">Stats</Link>
-        </div>
-      </footer>
+      <FooterBar canInstall={canInstall} install={install} installed={installed} />
     </div>
   )
-}
-
-function labelFor(t: BetType) {
-  switch(t){
-    case 'single': return 'Single (18:1)'
-    case 'split': return 'Split (8:1)'
-    case 'quarter': return 'Corners (3:1)'
-    case 'even': return 'Even (1:1)'
-    case 'odd': return 'Odd (1:1)'
-    case 'high': return 'High 11–20 (1:1)'
-    case 'low': return 'Low 1–10 (1:1)'
-  }
-}
-
-function clampInt(n: number, min: number, max: number): number {
-  if(!Number.isFinite(n)) return min
-  n = Math.floor(n)
-  return Math.min(max, Math.max(min, n))
 }
 
 function isAdjacent(a:number,b:number): boolean {
@@ -378,14 +260,4 @@ function isAdjacent(a:number,b:number): boolean {
   const A = pos(a), B = pos(b)
   const dr = Math.abs(A.r-B.r), dc = Math.abs(A.c-B.c)
   return (dr+dc===1)
-}
-
-function fmtUSD(credits: number): string {
-  const dollars = credits * CREDIT_VALUE
-  return dollars.toLocaleString(undefined, { style: 'currency', currency: 'USD', minimumFractionDigits: 2 })
-}
-function fmtUSDSign(credits: number): string {
-  const dollars = credits * CREDIT_VALUE
-  const str = Math.abs(dollars).toLocaleString(undefined, { style: 'currency', currency: 'USD', minimumFractionDigits: 2 })
-  return (dollars >= 0 ? '+' : '−') + str
 }

--- a/src/components/BetBoard.tsx
+++ b/src/components/BetBoard.tsx
@@ -1,0 +1,27 @@
+import React from 'react'
+import { BetGrid } from './BetGrid'
+import type { BetMode } from '../types'
+
+interface Props {
+  grid: number[][]
+  mode: BetMode['kind']
+  onCellClick: (n: number) => void
+  splitFirst?: number
+  covered: Set<number>
+  winning: number | null
+}
+
+export function BetBoard({ grid, mode, onCellClick, splitFirst, covered, winning }: Props){
+  return (
+    <section className="table-wrap">
+      <BetGrid
+        grid={grid}
+        mode={mode}
+        onCellClick={onCellClick}
+        splitFirst={splitFirst}
+        covered={covered}
+        winning={winning}
+      />
+    </section>
+  )
+}

--- a/src/components/BetControls.tsx
+++ b/src/components/BetControls.tsx
@@ -1,0 +1,87 @@
+import React from 'react'
+import type { BetType } from '../game/engine'
+import type { BetMode, Player, RoundState } from '../types'
+import { clampInt } from '../utils'
+
+interface Props {
+  amount: number
+  setAmount: (n: number) => void
+  minBet: number
+  maxForActive: number
+  active: Player
+  mode: BetMode
+  setMode: React.Dispatch<React.SetStateAction<BetMode>>
+  roundState: RoundState
+  undoLast: (pid: number) => void
+  clearBets: (pid: number) => void
+  lockRound: () => void
+  enteredRoll: number | ''
+  setEnteredRoll: (n: number | '') => void
+  settleRound: () => void
+  newRound: () => void
+}
+
+export function BetControls({ amount, setAmount, minBet, maxForActive, active, mode, setMode, roundState, undoLast, clearBets, lockRound, enteredRoll, setEnteredRoll, settleRound, newRound }: Props){
+  const canPlaceActive = roundState==='open' && amount>=minBet && amount<=active.pool
+
+  return (
+    <section className="controls">
+      <div className="amount">
+        <label>Bet: </label>
+        <input
+          type="number" min={minBet} max={maxForActive} step={1}
+          value={amount}
+          onChange={(e)=> setAmount(clampInt(e.target.valueAsNumber || minBet, minBet, maxForActive))}
+          disabled={active.pool === 0}
+        />
+        <span className="hint">(min {minBet}, remaining pool {active.pool})</span>
+        <span className="active-name">Active: {active.name}</span>
+      </div>
+
+      <div className="betmodes">
+        {(['single','split','quarter','even','odd','high','low'] as BetType[]).map(k => (
+          <button
+            key={k}
+            className={(mode as any).kind === k ? 'active' : ''}
+            onClick={()=> setMode(k==='split' ? {kind:'split'} : {kind: k as any})}
+            disabled={roundState!=='open' || !canPlaceActive}>
+            {labelFor(k)}
+          </button>
+        ))}
+      </div>
+
+      <div className="actions">
+        <button onClick={()=>undoLast(active.id)} disabled={roundState!=='open' || active.bets.length===0}>Undo</button>
+        <button onClick={()=>clearBets(active.id)} disabled={roundState!=='open' || active.bets.length===0}>Clear</button>
+        <button onClick={lockRound} disabled={roundState!=='open'}>Lock Bets</button>
+        <div className="manual-roll">
+          <input
+            type="number" min={1} max={20} placeholder="roll 1–20"
+            value={enteredRoll}
+            onChange={e=> setEnteredRoll((() => {
+              const v = e.target.valueAsNumber
+              if(!Number.isFinite(v)) return '' as const
+              const n = clampInt(v, 1, 20)
+              return n as unknown as number
+            })())}
+            disabled={roundState!=='locked'}
+          />
+          <button onClick={settleRound} disabled={roundState!=='locked' || !enteredRoll}>Settle</button>
+          <button onClick={newRound} disabled={roundState!=='settled'}>New Round</button>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+function labelFor(t: BetType) {
+  switch(t){
+    case 'single': return 'Single (18:1)'
+    case 'split': return 'Split (8:1)'
+    case 'quarter': return 'Corners (3:1)'
+    case 'even': return 'Even (1:1)'
+    case 'odd': return 'Odd (1:1)'
+    case 'high': return 'High 11–20 (1:1)'
+    case 'low': return 'Low 1–10 (1:1)'
+  }
+}

--- a/src/components/FooterBar.tsx
+++ b/src/components/FooterBar.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import { Link } from 'react-router-dom'
+
+interface Props {
+  canInstall: boolean
+  install: () => void
+  installed: boolean
+}
+
+export function FooterBar({ canInstall, install, installed }: Props){
+  return (
+    <footer className="footer-bar">
+      <div className="left">
+        {canInstall && <button className="install-btn" onClick={install}>Install</button>}
+        {installed && <span className="installed">Installed</span>}
+      </div>
+      <div className="center">© Kraken Consulting, LLC (Dev Team)</div>
+      <div className="right">
+        <Link className="link-btn" to="/stats">Stats</Link>
+      </div>
+    </footer>
+  )
+}

--- a/src/components/HistorySection.tsx
+++ b/src/components/HistorySection.tsx
@@ -1,0 +1,42 @@
+import React from 'react'
+import type { Player } from '../types'
+
+interface Entry { roll: number, deltas: Record<number, number>, time: number }
+
+interface Props {
+  history: Entry[]
+  players: Player[]
+  fmtUSDSign: (credits: number) => string
+}
+
+export function HistorySection({ history, players, fmtUSDSign }: Props){
+  return (
+    <section className="history">
+      <h3>History</h3>
+      {history.length===0 ? <div className="muted">No rounds yet.</div> : (
+        <table>
+          <thead>
+            <tr>
+              <th>Roll</th>
+              {players.map(p=> <th key={p.id}>{p.name} Δ</th>)}
+              <th>Time</th>
+            </tr>
+          </thead>
+          <tbody>
+            {history.map((h,i)=>(
+              <tr key={i}>
+                <td>{h.roll}</td>
+                {players.map(p => {
+                  const d = h.deltas[p.id] ?? 0
+                  const cls = d>=0 ? 'pos' : 'neg'
+                  return <td key={p.id} className={cls}>{fmtUSDSign(d)}</td>
+                })}
+                <td>{new Date(h.time).toLocaleTimeString()}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </section>
+  )
+}

--- a/src/hooks/useBetActions.ts
+++ b/src/hooks/useBetActions.ts
@@ -1,0 +1,43 @@
+import React from 'react'
+import type { Bet } from '../game/engine'
+import type { Player, BetMode, RoundState } from '../types'
+
+interface Options {
+  roundState: RoundState
+  setPlayers: React.Dispatch<React.SetStateAction<Player[]>>
+  mode: BetMode
+  setMode: React.Dispatch<React.SetStateAction<BetMode>>
+  perRoundPool: number
+}
+
+export function useBetActions({ roundState, setPlayers, mode, setMode, perRoundPool }: Options){
+  const addBetFor = React.useCallback((pid: number, bet: Omit<Bet, 'id'>) => {
+    setPlayers(prev => prev.map(p => {
+      if(p.id !== pid) return p
+      if(roundState !== 'open') return p
+      if(bet.amount < 1 || bet.amount > p.pool) return p
+      const id = String(Date.now()) + '-' + Math.random().toString(36).slice(2,7)
+      return { ...p, bets: [...p.bets, { ...bet, id }], pool: p.pool - bet.amount }
+    }))
+  }, [roundState, setPlayers])
+
+  const undoLast = React.useCallback((pid: number) => {
+    if(roundState !== 'open') return
+    setPlayers(prev => prev.map(p => {
+      if(p.id !== pid) return p
+      const last = p.bets[p.bets.length-1]
+      if(!last) return p
+      const bets = p.bets.slice(0, -1)
+      return { ...p, bets, pool: p.pool + last.amount }
+    }))
+    if(mode.kind==='split' && (mode as any).first){ setMode({kind:'split'}) }
+  }, [roundState, setPlayers, mode, setMode])
+
+  const clearBets = React.useCallback((pid: number) => {
+    if(roundState !== 'open') return
+    setPlayers(prev => prev.map(p => p.id===pid ? ({ ...p, pool: perRoundPool, bets: [] }) : p))
+    if(mode.kind==='split' && (mode as any).first){ setMode({kind:'split'}) }
+  }, [roundState, setPlayers, mode, setMode, perRoundPool])
+
+  return { addBetFor, undoLast, clearBets }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,20 @@
+import type { Bet } from './game/engine'
+
+export type BetMode =
+  | { kind: 'single' }
+  | { kind: 'split'; first?: number }
+  | { kind: 'quarter' }
+  | { kind: 'high' }
+  | { kind: 'low' }
+  | { kind: 'even' }
+  | { kind: 'odd' }
+
+export type RoundState = 'open' | 'locked' | 'settled'
+
+export interface Player {
+  id: number
+  name: string
+  bets: Bet[]
+  pool: number
+  bank: number
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,18 @@
+export const CREDIT_VALUE = 0.25
+
+export function clampInt(n: number, min: number, max: number): number {
+  if(!Number.isFinite(n)) return min
+  n = Math.floor(n)
+  return Math.min(max, Math.max(min, n))
+}
+
+export function fmtUSD(credits: number): string {
+  const dollars = credits * CREDIT_VALUE
+  return dollars.toLocaleString(undefined, { style: 'currency', currency: 'USD', minimumFractionDigits: 2 })
+}
+
+export function fmtUSDSign(credits: number): string {
+  const dollars = credits * CREDIT_VALUE
+  const str = Math.abs(dollars).toLocaleString(undefined, { style: 'currency', currency: 'USD', minimumFractionDigits: 2 })
+  return (dollars >= 0 ? '+' : '−') + str
+}


### PR DESCRIPTION
## Summary
- split controls, board, history, and footer into dedicated React components
- centralize bet manipulation logic via new `useBetActions` hook
- extract shared utilities and types to dedicated modules

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a7495bfb048322ab6cd531da9e2818