### PR TITLE
Add player and house management pages with navigation

### DIFF
--- a/src/House.tsx
+++ b/src/House.tsx
@@ -1,1 +1,68 @@
-export default function House() { return <div>House page</div>; }
+import React from 'react'
+import { Link } from 'react-router-dom'
+import { usePlayers, useRoundState, useStats, PER_ROUND_POOL } from './context/GameContext'
+import { fmtUSDSign } from './utils'
+import { useInstallPrompt } from './pwa/useInstallPrompt'
+
+export default function House() {
+  const { players, setPlayers } = usePlayers()
+  const { roundState, setRoundState } = useRoundState()
+  const { stats } = useStats()
+  const { canInstall, install, installed } = useInstallPrompt()
+
+  const newRound = () => {
+    setPlayers(prev => prev.map(p => ({ ...p, pool: PER_ROUND_POOL, bets: [] })))
+    setRoundState('open')
+  }
+
+  return (
+    <div className="container">
+      <header className="header">
+        <div className="left" />
+        <h1>House Management</h1>
+        <div className="right" />
+      </header>
+
+      <section className="controls">
+        <div className="amount">
+          <div>
+            <strong>Round State:</strong>{' '}
+            <span className={`roundstate ${roundState}`}>{roundState.toUpperCase()}</span>
+          </div>
+          <div className="ctrl-btns">
+            <button onClick={() => setRoundState('locked')}>Lock</button>
+            <button onClick={() => setRoundState('settled')}>Settle</button>
+            <button onClick={newRound}>New Round</button>
+          </div>
+        </div>
+      </section>
+
+      <section className="bets">
+        <h3>Overall Stats</h3>
+        <div><strong>Rounds Played:</strong> {stats.rounds}</div>
+        <h4>Player Banks</h4>
+        <ul>
+          {players.map(p => (
+            <li key={p.id}>
+              <span>{p.name}</span>
+              <span> — </span>
+              <strong className={p.bank>=0?'pos':'neg'}>{fmtUSDSign(p.bank)}</strong>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <footer className="footer-bar">
+        <div className="left">
+          {canInstall && <button className="install-btn" onClick={install}>Install</button>}
+          {installed && <span className="installed">Installed</span>}
+        </div>
+        <div className="center">© Kraken Consulting, LLC (Dev Team)</div>
+        <div className="right">
+          <Link className="link-btn" to="/">Game</Link>
+        </div>
+      </footer>
+    </div>
+  )
+}
+

--- a/src/Player.tsx
+++ b/src/Player.tsx
@@ -1,1 +1,80 @@
-export default function Player() { return <div>Player page</div>; }
+import React from 'react'
+import { Link } from 'react-router-dom'
+import { usePlayers } from './context/GameContext'
+import { fmtUSD, fmtUSDSign } from './utils'
+import { getOdds } from './game/engine'
+import type { Bet } from './game/engine'
+import { useInstallPrompt } from './pwa/useInstallPrompt'
+
+function describeBet(b: Bet): string {
+  switch (b.type) {
+    case 'single':
+      return `#${b.selection[0]}`
+    case 'split':
+      return `Split ${b.selection.join(' / ')}`
+    case 'quarter':
+      return `Corners ${b.selection.join('-')}`
+    case 'even':
+      return 'Even'
+    case 'odd':
+      return 'Odd'
+    case 'high':
+      return 'High 11–20'
+    case 'low':
+      return 'Low 1–10'
+  }
+}
+
+function potential(b: Bet): number {
+  return b.amount * getOdds(b.type)
+}
+
+export default function Player() {
+  const { players } = usePlayers()
+  const { canInstall, install, installed } = useInstallPrompt()
+
+  return (
+    <div className="container">
+      <header className="header">
+        <div className="left" />
+        <h1>Player Summary</h1>
+        <div className="right" />
+      </header>
+
+      <section className="bets">
+        {players.map(p => (
+          <div key={p.id} className="player">
+            <div className="name">{p.name}</div>
+            <div className="line"><span>Bank</span><strong className={p.bank>=0?'pos':'neg'}>{fmtUSDSign(p.bank)}</strong></div>
+            <div className="line"><span>Pool</span><strong>{p.pool}</strong></div>
+            <h4>Bets</h4>
+            {p.bets.length ? (
+              <ul>
+                {p.bets.map((b, i) => (
+                  <li key={i}>
+                    <span>{describeBet(b)}</span>
+                    <span> — {fmtUSD(b.amount)} → {fmtUSD(potential(b))}</span>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <div>No bets placed</div>
+            )}
+          </div>
+        ))}
+      </section>
+
+      <footer className="footer-bar">
+        <div className="left">
+          {canInstall && <button className="install-btn" onClick={install}>Install</button>}
+          {installed && <span className="installed">Installed</span>}
+        </div>
+        <div className="center">© Kraken Consulting, LLC (Dev Team)</div>
+        <div className="right">
+          <Link className="link-btn" to="/">Game</Link>
+        </div>
+      </footer>
+    </div>
+  )
+}
+

--- a/src/components/FooterBar.tsx
+++ b/src/components/FooterBar.tsx
@@ -16,6 +16,8 @@ export function FooterBar({ canInstall, install, installed }: Props){
       </div>
       <div className="center">© Kraken Consulting, LLC (Dev Team)</div>
       <div className="right">
+        <Link className="link-btn" to="/player">Players</Link>
+        <Link className="link-btn" to="/house">House</Link>
         <Link className="link-btn" to="/stats">Stats</Link>
       </div>
     </footer>

--- a/src/styles.css
+++ b/src/styles.css
@@ -131,4 +131,4 @@ body{
 }
 .footer-bar .left{ justify-self: start; display:flex; gap:8px; align-items:center; }
 .footer-bar .center{ justify-self: center; font-size: 12px; }
-.footer-bar .right{ justify-self: end; }
+.footer-bar .right{ justify-self: end; display:flex; gap:8px; }


### PR DESCRIPTION
## Summary
- Build detailed player summary page showing bank, pool and bets
- Create house management view with round controls and overall stats
- Expand footer navigation with links to players, house and stats

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a780e02d608322bf83d348af076f60