### PR TITLE
feat: improve bet grid accessibility and feedback

### DIFF
--- a/src/components/BetGrid.tsx
+++ b/src/components/BetGrid.tsx
@@ -10,27 +10,70 @@ interface Props {
 }
 
 export function BetGrid({ grid, mode, splitFirst, onCellClick, covered, winning }: Props){
+  const cellRefs = React.useRef<Record<number, HTMLButtonElement | null>>({})
+
+  const handleKey = (
+    e: React.KeyboardEvent<HTMLButtonElement>,
+    rIdx: number,
+    cIdx: number
+  ) => {
+    let target: number | undefined
+    switch (e.key) {
+      case 'ArrowRight':
+        target = grid[rIdx][cIdx + 1]
+        break
+      case 'ArrowLeft':
+        target = grid[rIdx][cIdx - 1]
+        break
+      case 'ArrowDown':
+        target = grid[rIdx + 1]?.[cIdx]
+        break
+      case 'ArrowUp':
+        target = grid[rIdx - 1]?.[cIdx]
+        break
+      default:
+        return
+    }
+    if (target != null) {
+      cellRefs.current[target]?.focus()
+      e.preventDefault()
+    }
+  }
+
   return (
     <div className="betgrid">
-      <div className="grid">
-        {grid.map((row, rIdx)=>(
-          <div className="row" key={rIdx}>
-            {row.map(n => {
+      <div className="grid" role="grid">
+        {grid.map((row, rIdx) => (
+          <div className="row" role="row" key={rIdx}>
+            {row.map((n, cIdx) => {
               const isCovered = covered.has(n)
               const isWin = winning === n
-              const cls = 'cell' + (splitFirst===n ? ' pending' : '') + (isCovered ? ' covered' : '') + (isWin ? ' winning' : '')
+              const cls =
+                'cell' +
+                (splitFirst === n ? ' pending' : '') +
+                (isCovered ? ' covered' : '') +
+                (isWin ? ' winning' : '')
               return (
                 <button
+                  ref={el => (cellRefs.current[n] = el)}
+                  role="gridcell"
+                  tabIndex={0}
+                  aria-selected={isCovered}
                   className={cls}
                   key={n}
-                  onClick={()=>onCellClick(n)}
+                  onClick={() => onCellClick(n)}
+                  onKeyDown={e => handleKey(e, rIdx, cIdx)}
                   title={
-                    mode==='quarter' ? 'Corners anchor (top-left of a 2x2)' :
-                    mode==='split' ? (splitFirst ? `Choose an adjacent cell to ${splitFirst}` : 'Choose first cell for split') :
-                    'Single number'
+                    mode === 'quarter'
+                      ? 'Corners anchor (top-left of a 2x2)'
+                      : mode === 'split'
+                      ? splitFirst
+                        ? `Choose an adjacent cell to ${splitFirst}`
+                        : 'Choose first cell for split'
+                      : 'Single number'
                   }
                 >
-                  {String(n).padStart(2,'0')}
+                  {String(n).padStart(2, '0')}
                 </button>
               )
             })}

--- a/src/styles.css
+++ b/src/styles.css
@@ -105,10 +105,32 @@ body{
 .betgrid .cell{
   padding: 12px 0; border-radius: 12px; border: 2px solid #334155; background: #0f172a; color: var(--text);
   text-align: center; font-variant-numeric: tabular-nums;
+  transition: background-color .3s, border-color .3s, box-shadow .3s;
 }
 .betgrid .cell.pending{ outline: 2px dashed var(--accent); }
-.betgrid .cell.covered{ border-color: var(--gold); box-shadow: 0 0 0 2px rgba(250, 204, 21, 0.2) inset; }
-.betgrid .cell.winning{ background: var(--winbg); border-color: #10b981; }
+.betgrid .cell.covered{
+  border-color: var(--gold); box-shadow: 0 0 0 2px rgba(250, 204, 21, 0.2) inset;
+  animation: betflash .4s ease-out;
+}
+.betgrid .cell.winning{
+  background: var(--winbg); border-color: #10b981;
+  animation: winpulse 1s ease-in-out infinite alternate;
+}
+
+@keyframes betflash {
+  from { background: rgba(250, 204, 21, 0.2); }
+  to { background: #0f172a; }
+}
+
+@keyframes winpulse {
+  from { box-shadow: 0 0 0 0 rgba(16,185,129,0.7); }
+  to { box-shadow: 0 0 10px 4px rgba(16,185,129,0); }
+}
+
+@media (max-width: 480px){
+  .betgrid .row{ grid-template-columns: repeat(5, minmax(0,1fr)); gap:4px; }
+  .betgrid .cell{ padding:8px 0; font-size:14px; }
+}
 
 .bets, .history{ background: var(--panel); padding: 12px; border-radius: 12px; margin-bottom:12px; }
 .bets ul{ list-style: none; padding: 0; margin: 0; display: grid; gap: 6px; }


### PR DESCRIPTION
## Summary
- add keyboard arrow navigation and ARIA grid roles to bet grid
- animate new bets and winning numbers, adjust mobile spacing

## Testing
- `npm test -- --run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a7842d8be48322bb5d6366a27a3363