### PR TITLE
Add offline fallback and API caching

### DIFF
--- a/public/offline.html
+++ b/public/offline.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Offline - Roll-et</title>
+    <style>
+      body {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 100vh;
+        font-family: sans-serif;
+        text-align: center;
+        background: #0b1220;
+        color: #fff;
+        margin: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <p>You are offline. Please check your internet connection.</p>
+  </body>
+</html>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,8 +12,27 @@ export default defineConfig({
          cleanupOutdatedCaches: true,
          clientsClaim: true,
          skipWaiting: true,
+         navigateFallback: '/roll-et/offline.html',
+         runtimeCaching: [
+           {
+             urlPattern: ({ url }) => url.pathname.startsWith('/api'),
+             method: 'GET',
+             handler: 'NetworkFirst',
+             options: {
+               cacheName: 'api-cache',
+               networkTimeoutSeconds: 10,
+               expiration: {
+                 maxEntries: 50,
+                 maxAgeSeconds: 60 * 60,
+               },
+               cacheableResponse: {
+                 statuses: [0, 200],
+               },
+             },
+           },
+         ],
       },
-      includeAssets: ['icons/icon-192.png','icons/icon-512.png','icons/maskable-192.png','icons/maskable-512.png','favicon.svg'],
+      includeAssets: ['icons/icon-192.png','icons/icon-512.png','icons/maskable-192.png','icons/maskable-512.png','favicon.svg','offline.html'],
       manifest: {
         name: 'Roll‑et',
         short_name: 'Roll‑et',


### PR DESCRIPTION
## Summary
- cache API responses via new Workbox runtimeCaching rule
- serve offline.html when navigation fails
- include offline fallback page in PWA assets

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a785f8db988322a23507a776d1591e