### PR TITLE
Add CI workflow with caching and badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+
+      - name: Build
+        run: npm run build

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Roll‑et PWA (React + Vite)
 
+[![CI](https://github.com/dbailey1564/roll-et/actions/workflows/ci.yml/badge.svg)](https://github.com/dbailey1564/roll-et/actions/workflows/ci.yml)
+
 Summary:
 - React + Vite + TypeScript.
 - PWA via `vite-plugin-pwa` (autoUpdate).


### PR DESCRIPTION
## Summary
- add GitHub Actions CI workflow running install, test, and build steps with cached npm modules
- document CI badge in README

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a788345004832294b1dd1cf4947610