### PR TITLE
docs: list bet categories with payouts

### DIFF
--- a/docs/rollet_master_game_design_overview.md
+++ b/docs/rollet_master_game_design_overview.md
@@ -16,9 +16,13 @@ This document consolidates all game rules, player flow, and contract definitions
   5. **Settled** — Credits liquidated to winnings/losses → tender or BANK.
 
 - **Betting Options:**
-  - Single numbers → 18:1 payout.
-  - Splits → 8:1 payout.
-  - Quarters included.
+  - **Single** (exact number) → 18:1 payout.
+  - **Split** (two adjacent numbers) → 8:1 payout.
+  - **Quarter** (2×2 block) → 3:1 payout.
+  - **Even** → 1:1 payout.
+  - **Odd** → 1:1 payout.
+  - **High** (11–20) → 1:1 payout.
+  - **Low** (1–10) → 1:1 payout.
   - No thirds, Lucky 7, or prime/composite bets.
 
 ---


### PR DESCRIPTION
## Summary
- document all supported bet categories and their payout multipliers
- ensure documentation matches `OddsTable` in game engine

## Testing
- `npx vitest run --environment jsdom`


------
https://chatgpt.com/codex/tasks/task_e_68a7e845f1748322a77b5cec184365f0