### PR TITLE
Rename quarter bets to corner

### DIFF
--- a/docs/rollet_master_game_design_overview.md
+++ b/docs/rollet_master_game_design_overview.md
@@ -18,7 +18,7 @@ This document consolidates all game rules, player flow, and contract definitions
 - **Betting Options:**
   - **Single** (exact number) → 18:1 payout.
   - **Split** (two adjacent numbers) → 8:1 payout.
-  - **Quarter** (2×2 block) → 3:1 payout.
+  - **Corner** (2×2 block) → 3:1 payout.
   - **Even** → 1:1 payout.
   - **Odd** → 1:1 payout.
   - **High** (11–20) → 1:1 payout.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@ import { BetBoard } from './components/BetBoard'
 import { BetControls } from './components/BetControls'
 import { HistorySection } from './components/HistorySection'
 import { FooterBar } from './components/FooterBar'
-import { Bet, makeQuarterFromAnchor, resolveRound, numberGrid, getOdds } from './game/engine'
+import { Bet, makeCornerFromAnchor, resolveRound, numberGrid, getOdds } from './game/engine'
 import { useInstallPrompt } from './pwa/useInstallPrompt'
 import type { BetMode, Player } from './types'
 import { clampInt, fmtUSD, fmtUSDSign } from './utils'
@@ -48,7 +48,7 @@ export default function App() {
     for(const p of players){
       for(const b of p.bets){
         switch(b.type){
-          case 'single': case 'split': case 'quarter':
+          case 'single': case 'split': case 'corner':
             b.selection.forEach(n => s.add(n)); break
           case 'even':
             for(let n=2;n<=20;n+=2) s.add(n); break
@@ -92,9 +92,9 @@ export default function App() {
         }
         break
       }
-      case 'quarter': {
-        const q = makeQuarterFromAnchor(n)
-        if(q) addBetFor(p.id, { type:'quarter', selection: q, amount })
+      case 'corner': {
+        const q = makeCornerFromAnchor(n)
+        if(q) addBetFor(p.id, { type:'corner', selection: q, amount })
         break
       }
       case 'high':
@@ -153,7 +153,7 @@ export default function App() {
     switch(b.type){
       case 'single': return `#${b.selection[0]}`
       case 'split': return `Split ${b.selection.join(' / ')}`
-      case 'quarter': return `Corners ${b.selection.join('-')}`
+      case 'corner': return `Corner ${b.selection.join('-')}`
       case 'even': return 'Even'
       case 'odd': return 'Odd'
       case 'high': return 'High 11–20'

--- a/src/Player.tsx
+++ b/src/Player.tsx
@@ -12,8 +12,8 @@ function describeBet(b: Bet): string {
       return `#${b.selection[0]}`
     case 'split':
       return `Split ${b.selection.join(' / ')}`
-    case 'quarter':
-      return `Corners ${b.selection.join('-')}`
+    case 'corner':
+      return `Corner ${b.selection.join('-')}`
     case 'even':
       return 'Even'
     case 'odd':

--- a/src/__tests__/engine.test.ts
+++ b/src/__tests__/engine.test.ts
@@ -1,18 +1,18 @@
 import { describe, it, expect } from 'vitest'
-import { makeQuarterFromAnchor, resolveRound, wins, type Bet } from '../game/engine'
+import { makeCornerFromAnchor, resolveRound, wins, type Bet } from '../game/engine'
 
-describe('makeQuarterFromAnchor', () => {
-  it('returns correct quarter for valid anchor', () => {
-    expect(makeQuarterFromAnchor(1)).toEqual([1, 2, 6, 7])
+describe('makeCornerFromAnchor', () => {
+  it('returns correct corner for valid anchor', () => {
+    expect(makeCornerFromAnchor(1)).toEqual([1, 2, 6, 7])
   })
 
   it('returns null for anchor on the right edge', () => {
-    expect(makeQuarterFromAnchor(5)).toBeNull()
+    expect(makeCornerFromAnchor(5)).toBeNull()
   })
 
   it('returns null for anchors outside the grid', () => {
-    expect(makeQuarterFromAnchor(0)).toBeNull()
-    expect(makeQuarterFromAnchor(21)).toBeNull()
+    expect(makeCornerFromAnchor(0)).toBeNull()
+    expect(makeCornerFromAnchor(21)).toBeNull()
   })
 })
 
@@ -31,8 +31,8 @@ describe('wins', () => {
     expect(wins(bet('split', [5, 6]), 6)).toBe(true)
     expect(wins(bet('split', [5, 6]), 7)).toBe(false)
 
-    expect(wins(bet('quarter', [1, 2, 6, 7]), 7)).toBe(true)
-    expect(wins(bet('quarter', [1, 2, 6, 7]), 8)).toBe(false)
+    expect(wins(bet('corner', [1, 2, 6, 7]), 7)).toBe(true)
+    expect(wins(bet('corner', [1, 2, 6, 7]), 8)).toBe(false)
   })
 
   it('evaluates parity and range bets', () => {
@@ -55,7 +55,7 @@ describe('resolveRound', () => {
     const bets: Bet[] = [
       { id: 'b1', type: 'single', selection: [7], amount: 10 },
       { id: 'b2', type: 'even', selection: [], amount: 5 },
-      { id: 'b3', type: 'quarter', selection: [6, 7, 11, 12], amount: 10 },
+      { id: 'b3', type: 'corner', selection: [6, 7, 11, 12], amount: 10 },
     ]
     expect(resolveRound(7, bets)).toBe(10 * 18 + 10 * 3)
   })

--- a/src/components/BetControls.tsx
+++ b/src/components/BetControls.tsx
@@ -39,7 +39,7 @@ export function BetControls({ amount, setAmount, minBet, maxForActive, active, m
       </div>
 
       <div className="betmodes">
-        {(['single','split','quarter','even','odd','high','low'] as BetType[]).map(k => (
+        {(['single','split','corner','even','odd','high','low'] as BetType[]).map(k => (
           <button
             key={k}
             className={(mode as any).kind === k ? 'active' : ''}
@@ -78,7 +78,7 @@ function labelFor(t: BetType) {
   switch(t){
     case 'single': return 'Single (18:1)'
     case 'split': return 'Split (8:1)'
-    case 'quarter': return 'Corners (3:1)'
+    case 'corner': return 'Corner (3:1)'
     case 'even': return 'Even (1:1)'
     case 'odd': return 'Odd (1:1)'
     case 'high': return 'High 11–20 (1:1)'

--- a/src/components/BetGrid.tsx
+++ b/src/components/BetGrid.tsx
@@ -64,8 +64,8 @@ export function BetGrid({ grid, mode, splitFirst, onCellClick, covered, winning 
                   onClick={() => onCellClick(n)}
                   onKeyDown={e => handleKey(e, rIdx, cIdx)}
                   title={
-                    mode === 'quarter'
-                      ? 'Corners anchor (top-left of a 2x2)'
+                    mode === 'corner'
+                      ? 'Corner anchor (top-left of a 2×2)'
                       : mode === 'split'
                       ? splitFirst
                         ? `Choose an adjacent cell to ${splitFirst}`

--- a/src/game/engine.ts
+++ b/src/game/engine.ts
@@ -1,4 +1,4 @@
-export type BetType = 'single' | 'split' | 'quarter' | 'even' | 'odd' | 'high' | 'low'
+export type BetType = 'single' | 'split' | 'corner' | 'even' | 'odd' | 'high' | 'low'
 
 export interface Bet {
   id: string
@@ -10,7 +10,7 @@ export interface Bet {
 export const OddsTable = {
   single: 18,
   split: 8,
-  quarter: 3,
+  corner: 3,
   high: 1,
   low: 1,
   even: 1,
@@ -26,7 +26,7 @@ export const numberGrid: number[][] = [
   [16,17,18,19,20],
 ]
 
-export function makeQuarterFromAnchor(anchor: number): number[] | null {
+export function makeCornerFromAnchor(anchor: number): number[] | null {
   const idx = anchor - 1
   const r = Math.floor(idx/5), c = idx%5
   if(r>=0 && r<3 && c>=0 && c<4) {
@@ -53,7 +53,7 @@ export function wins(b: Bet, roll: number): boolean {
   switch(b.type){
     case 'single': return b.selection[0] === roll
     case 'split': return b.selection.includes(roll)
-    case 'quarter': return b.selection.includes(roll)
+    case 'corner': return b.selection.includes(roll)
     case 'even': return roll % 2 === 0
     case 'odd': return roll % 2 === 1
     case 'high': return roll >= 11

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,7 @@ import type { Bet } from './game/engine'
 export type BetMode =
   | { kind: 'single' }
   | { kind: 'split'; first?: number }
-  | { kind: 'quarter' }
+  | { kind: 'corner' }
   | { kind: 'high' }
   | { kind: 'low' }
   | { kind: 'even' }


### PR DESCRIPTION
## Summary
- rename "quarter" bet to "corner" across game engine, components, and tests
- describe "Corner (2×2 block)" in game design docs and UI labels

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a7f3550c5083228436ffcda0bb9748