### PR TITLE
docs: add documentation section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,14 @@ npm run preview
 4. The included workflow publishes `/dist` to `gh-pages` branch.
 5. Site URL: https://dbailey1564.github.io/roll-et/
 
+## Documentation
+- [Master Game Design Overview](docs/rollet_master_game_design_overview.md) — consolidated rules, round flow, and contract references for Roll‑et.
+- [House Certificate Contract](docs/house_certificate_contract.md) — licensing model that authorizes houses to host rounds and sign artifacts.
+- [Join Challenge/Response Contract](docs/join_challenge_response_contract.md) — secure offline admission protocol binding players to a specific round.
+- [Bet Certificate Contract](docs/bet_certificate_contract.md) — portable proof of a player's locked bet, tied to round and bank reference.
+- [BANK Receipt Contract](docs/bank_receipt_contract.md) — signed record of settled winnings that can be redeemed or stored.
+- [Ledger & Sync Contract](docs/ledger_sync_contract.md) — append-only ledger format and synchronization rules with the authority backend.
+
 ## Notes
 - Start URL and scope are `/roll-et/`.
 - Service worker and manifest are generated at build time by the PWA plugin.


### PR DESCRIPTION
## Summary
- add Documentation section to README pointing to design overview and contract specs

## Testing
- `npm install`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a7f483e4488322956f77d4610724bc