### PR TITLE
Add join/host header with round lock

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,7 +16,6 @@ export default function App() {
   const { players, setPlayers } = usePlayers()
   const { roundState, setRoundState } = useRoundState()
   const { setStats } = useStats()
-  const [activePid, setActivePid] = React.useState<number>(1)
 
   const DEFAULT_BET = 1
   const [amount, setAmount] = React.useState<number>(() => {
@@ -34,14 +33,27 @@ export default function App() {
 
   const { canInstall, install, installed, isiOS } = useInstallPrompt()
 
-  const active = players.find(p => p.id === activePid)!
+  const [seat, setSeat] = React.useState<number | null>(null)
+  const [hosting, setHosting] = React.useState(false)
+
+  const joinGame = () => {
+    setSeat(1)
+    setRoundState('locked')
+  }
+
+  const hostGame = () => {
+    setHosting(true)
+    setRoundState('locked')
+  }
+
+  const active = players[0]
   const totalStake = (p: Player) => p.bets.reduce((a,b)=>a+b.amount, 0)
   const maxForActive = Math.max(MIN_BET, active.pool)
   const canPlace = (p: Player) => roundState==='open' && amount>=MIN_BET && amount<=p.pool
 
   React.useEffect(() => {
     setAmount(a => clampInt(a, MIN_BET, maxForActive))
-  }, [activePid, active.pool])
+  }, [active.pool])
 
   const covered = React.useMemo(() => {
     const s = new Set<number>()
@@ -166,29 +178,30 @@ export default function App() {
   return (
     <div className="container">
       <header className="header">
-        <div className="left" />
+        <div className="left">
+          {seat != null ? (
+            <span className="seat">Seat: {seat}</span>
+          ) : hosting ? (
+            <span className="seat">Seat: Open</span>
+          ) : (
+            <button className="link-btn" onClick={joinGame}>Join</button>
+          )}
+        </div>
         <h1>Roll-et</h1>
         <div className="right">
-          <div className="credits">
-            Round: <span className={`roundstate ${roundState}`}>{roundState.toUpperCase()}</span>
-          </div>
+          {hosting || seat != null ? (
+            <div className="credits">
+              Round: <span className={`roundstate ${roundState}`}>{roundState.toUpperCase()}</span>
+            </div>
+          ) : (
+            <button className="link-btn" onClick={hostGame}>Host</button>
+          )}
         </div>
       </header>
 
       {isiOS && !installed && (
         <div className="ios-hint">On iPhone/iPad: Share → Add to Home Screen to install.</div>
       )}
-
-      <section className="players">
-        {players.map(p => (
-          <button key={p.id} className={'player ' + (p.id===activePid?'active':'')} onClick={()=>setActivePid(p.id)}>
-            <div className="name">{p.name}</div>
-            <div className="line"><span>Pool</span><strong>{p.pool}/{PER_ROUND_POOL}</strong></div>
-            <div className="line"><span>Bank</span><strong className={p.bank>=0?'pos':'neg'}>{fmtUSDSign(p.bank)}</strong></div>
-            <div className="line"><span>Stake</span><strong>{fmtUSD(totalStake(p))}</strong></div>
-          </button>
-        ))}
-      </section>
 
       <BetControls
         amount={amount}
@@ -218,10 +231,10 @@ export default function App() {
       />
 
       <section className="bets">
-        <h3>{players.find(p=>p.id===activePid)?.name} Bets (potential payout)</h3>
-        {players.find(p=>p.id===activePid)!.bets.length===0 ? <div className="muted">No bets placed.</div> : (
+        <h3>Bets (potential payout)</h3>
+        {active.bets.length===0 ? <div className="muted">No bets placed.</div> : (
           <ul>
-            {players.find(p=>p.id===activePid)!.bets.map(b => (
+            {active.bets.map(b => (
               <li key={b.id}>
                 <span>{describeBet(b)}</span>
                 <span> × {b.amount} → </span>

--- a/src/components/BetControls.tsx
+++ b/src/components/BetControls.tsx
@@ -27,7 +27,6 @@ export function BetControls({ amount, setAmount, minBet, maxForActive, active, m
   return (
     <section className="controls">
       <div className="amount">
-        <label>Bet: </label>
         <input
           type="number" min={minBet} max={maxForActive} step={1}
           value={amount}
@@ -35,7 +34,6 @@ export function BetControls({ amount, setAmount, minBet, maxForActive, active, m
           disabled={active.pool === 0}
         />
         <span className="hint">(min {minBet}, remaining pool {active.pool})</span>
-        <span className="active-name">Active: {active.name}</span>
       </div>
 
       <div className="betmodes">

--- a/src/components/FooterBar.tsx
+++ b/src/components/FooterBar.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import { Link } from 'react-router-dom'
 
 interface Props {
   canInstall: boolean
@@ -15,11 +14,6 @@ export function FooterBar({ canInstall, install, installed }: Props){
         {installed && <span className="installed">Installed</span>}
       </div>
       <div className="center">© Kraken Consulting, LLC (Dev Team)</div>
-      <div className="right">
-        <Link className="link-btn" to="/player">Players</Link>
-        <Link className="link-btn" to="/house">House</Link>
-        <Link className="link-btn" to="/stats">Stats</Link>
-      </div>
     </footer>
   )
 }

--- a/src/context/GameContext.tsx
+++ b/src/context/GameContext.tsx
@@ -32,7 +32,7 @@ export const GameProvider: React.FC<{ children: React.ReactNode }> = ({ children
   ), [])
 
   const [players, setPlayers] = React.useState<Player[]>(playersInit)
-  const [roundState, setRoundState] = React.useState<RoundState>('open')
+  const [roundState, setRoundState] = React.useState<RoundState>('locked')
   const [stats, setStats] = React.useState<Stats>(() => {
     try {
       const raw = localStorage.getItem('roll_et_stats')

--- a/src/styles.css
+++ b/src/styles.css
@@ -68,7 +68,8 @@ body{
 .amount{ display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
 .amount input{ width: 96px; padding: 6px 8px; border-radius: 8px; border: 1px solid #334155; background: #0f172a; color: var(--text); }
 .hint{ color: var(--muted); font-size: 12px; }
-.active-name{ color: #86efac; }
+
+.seat{ font-weight: 600; }
 
 .actions{ display:flex; gap:8px; align-items:center; flex-wrap: wrap; }
 .actions button{ padding: 8px 10px; border-radius: 10px; border: 1px solid #334155; background: #0f172a; color: var(--text); }


### PR DESCRIPTION
## Summary
- Add Join and Host controls to the header with seat display and round status
- Initialize round state as locked until a game is joined or hosted
- Drop bet amount and active player labels from controls

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a84641d3a883229b58550edfdcf183