### PR TITLE
Use browser-safe encoding utilities

### DIFF
--- a/src/certs/bankReceipt.ts
+++ b/src/certs/bankReceipt.ts
@@ -1,3 +1,4 @@
+import { base64UrlEncode, base64UrlDecode } from '../encoding'
 const subtle = globalThis.crypto.subtle
 const encoder = new TextEncoder()
 
@@ -20,12 +21,12 @@ export interface BankReceipt extends BankReceiptPayload {
 async function signPayload(payload: BankReceiptPayload, key: CryptoKey): Promise<string> {
   const data = encoder.encode(JSON.stringify(payload))
   const sig = await subtle.sign({ name: 'ECDSA', hash: 'SHA-256' }, key, data)
-  return Buffer.from(sig).toString('base64url')
+  return base64UrlEncode(sig)
 }
 
 async function verifyPayload(payload: BankReceiptPayload, sig: string, key: CryptoKey): Promise<boolean> {
   const data = encoder.encode(JSON.stringify(payload))
-  const signature = Buffer.from(sig, 'base64url')
+  const signature = base64UrlDecode(sig)
   return subtle.verify({ name: 'ECDSA', hash: 'SHA-256' }, key, signature, data)
 }
 

--- a/src/certs/betCert.ts
+++ b/src/certs/betCert.ts
@@ -1,3 +1,4 @@
+import { base64UrlEncode, base64UrlDecode } from '../encoding'
 const subtle = globalThis.crypto.subtle
 const encoder = new TextEncoder()
 
@@ -19,12 +20,12 @@ export interface BetCert extends BetCertPayload {
 async function signPayload(payload: BetCertPayload, key: CryptoKey): Promise<string> {
   const data = encoder.encode(JSON.stringify(payload))
   const sig = await subtle.sign({ name: 'ECDSA', hash: 'SHA-256' }, key, data)
-  return Buffer.from(sig).toString('base64url')
+  return base64UrlEncode(sig)
 }
 
 async function verifyPayload(payload: BetCertPayload, sig: string, key: CryptoKey): Promise<boolean> {
   const data = encoder.encode(JSON.stringify(payload))
-  const signature = Buffer.from(sig, 'base64url')
+  const signature = base64UrlDecode(sig)
   return subtle.verify({ name: 'ECDSA', hash: 'SHA-256' }, key, signature, data)
 }
 

--- a/src/certs/houseCert.ts
+++ b/src/certs/houseCert.ts
@@ -1,3 +1,4 @@
+import { base64UrlEncode, base64UrlDecode } from '../encoding'
 const subtle = globalThis.crypto.subtle
 
 export interface HouseCertPayload {
@@ -18,12 +19,12 @@ const encoder = new TextEncoder()
 async function signPayload(payload: any, key: CryptoKey): Promise<string> {
   const data = encoder.encode(JSON.stringify(payload))
   const sig = await subtle.sign({ name: 'ECDSA', hash: 'SHA-256' }, key, data)
-  return Buffer.from(sig).toString('base64url')
+  return base64UrlEncode(sig)
 }
 
 async function verifyPayload(payload: any, signature: string, key: CryptoKey): Promise<boolean> {
   const data = encoder.encode(JSON.stringify(payload))
-  const sig = Buffer.from(signature, 'base64url')
+  const sig = base64UrlDecode(signature)
   return subtle.verify({ name: 'ECDSA', hash: 'SHA-256' }, key, sig, data)
 }
 

--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -1,0 +1,23 @@
+export function base64UrlEncode(data: ArrayBuffer | Uint8Array): string {
+  const bytes = data instanceof Uint8Array ? data : new Uint8Array(data)
+  let binary = ''
+  bytes.forEach(b => (binary += String.fromCharCode(b)))
+  const base64 = btoa(binary)
+  return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+export function base64UrlDecode(str: string): Uint8Array {
+  let base64 = str.replace(/-/g, '+').replace(/_/g, '/')
+  while (base64.length % 4) base64 += '='
+  const binary = atob(base64)
+  const bytes = new Uint8Array(binary.length)
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i)
+  }
+  return bytes
+}
+
+export function bytesToHex(data: ArrayBuffer | Uint8Array): string {
+  const bytes = data instanceof Uint8Array ? data : new Uint8Array(data)
+  return Array.from(bytes).map(b => b.toString(16).padStart(2, '0')).join('')
+}

--- a/src/round.ts
+++ b/src/round.ts
@@ -1,6 +1,7 @@
 import type { Player } from './types'
 import type { Bet } from './game/engine'
 import { generateBetCert, BetCert } from './certs/betCert'
+import { bytesToHex } from './encoding'
 const subtle = globalThis.crypto.subtle
 const encoder = new TextEncoder()
 
@@ -16,7 +17,7 @@ function uuid(): string {
 async function hashBets(bets: Bet[]): Promise<string> {
   const data = encoder.encode(JSON.stringify(bets))
   const hashBuf = await subtle.digest('SHA-256', data)
-  return Buffer.from(hashBuf).toString('hex')
+  return bytesToHex(hashBuf)
 }
 
 export async function lockRound(players: Player[], houseKey: CryptoKey, roundId: string): Promise<BetCert[]> {


### PR DESCRIPTION
## Summary
- replace Node Buffer base64 usage with browser-safe base64url helper
- add reusable base64url and hex encoding utilities
- update round hashing to avoid Buffer

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae455b41588322a801cb9fd6504d59