### PR TITLE
refactor: add base64 helpers

### DIFF
--- a/src/join.ts
+++ b/src/join.ts
@@ -1,5 +1,6 @@
 import { HouseCert, validateHouseCert } from './certs/houseCert'
 import QRCode from 'qrcode'
+import { bytesToBase64Url } from './utils/base64'
 
 const subtle = globalThis.crypto.subtle
 const encoder = new TextEncoder()
@@ -16,7 +17,7 @@ export interface JoinChallenge {
 export async function createJoinChallenge(houseCert: HouseCert, round: string, ttlMs: number = 15000): Promise<JoinChallenge> {
   const nonceArr = new Uint8Array(16)
   globalThis.crypto.getRandomValues(nonceArr)
-  const nonce = Buffer.from(nonceArr).toString('base64url')
+  const nonce = bytesToBase64Url(nonceArr)
   const now = Date.now()
   return { type: 'join-challenge', houseCert, round, nonce, nbf: now, exp: now + ttlMs }
 }
@@ -52,9 +53,9 @@ export async function createJoinResponse(
 ): Promise<JoinResponse> {
   const data = encoder.encode(`${playerId}|${challenge.round}|${challenge.nonce}`)
   const hmacBuf = await subtle.sign('HMAC', secret, data)
-  const hmac = Buffer.from(hmacBuf).toString('base64url')
+  const hmac = bytesToBase64Url(new Uint8Array(hmacBuf))
   const payload = { player: playerId, round: challenge.round, nonce: challenge.nonce, hmac, bankRef }
   const sigBuf = await subtle.sign({ name: 'ECDSA', hash: 'SHA-256' }, playerKey, encoder.encode(JSON.stringify(payload)))
-  const sig = Buffer.from(sigBuf).toString('base64url')
+  const sig = bytesToBase64Url(new Uint8Array(sigBuf))
   return { ...payload, sig }
 }

--- a/src/utils/base64.ts
+++ b/src/utils/base64.ts
@@ -1,0 +1,19 @@
+export function bytesToBase64Url(bytes: Uint8Array): string {
+  let binary = ''
+  for (const b of bytes) {
+    binary += String.fromCharCode(b)
+  }
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '')
+}
+
+export function base64UrlToBytes(base64url: string): Uint8Array {
+  const base64 = base64url.replace(/-/g, '+').replace(/_/g, '/')
+  const padLength = (4 - (base64.length % 4)) % 4
+  const padded = base64 + '='.repeat(padLength)
+  const binary = atob(padded)
+  const bytes = new Uint8Array(binary.length)
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i)
+  }
+  return bytes
+}


### PR DESCRIPTION
## Summary
- add base64url encode/decode helpers using Uint8Array and btoa/atob
- use new helpers in join challenge response generation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae47ba2ddc832281e5ca5e91be6487