### PR TITLE
refactor: use base64 util for cert signatures

### DIFF
--- a/src/certs/bankReceipt.ts
+++ b/src/certs/bankReceipt.ts
@@ -1,3 +1,5 @@
+import { bytesToBase64Url, base64UrlToBytes } from '../utils/base64'
+
 const subtle = globalThis.crypto.subtle
 const encoder = new TextEncoder()
 
@@ -20,12 +22,12 @@ export interface BankReceipt extends BankReceiptPayload {
 async function signPayload(payload: BankReceiptPayload, key: CryptoKey): Promise<string> {
   const data = encoder.encode(JSON.stringify(payload))
   const sig = await subtle.sign({ name: 'ECDSA', hash: 'SHA-256' }, key, data)
-  return Buffer.from(sig).toString('base64url')
+  return bytesToBase64Url(new Uint8Array(sig))
 }
 
 async function verifyPayload(payload: BankReceiptPayload, sig: string, key: CryptoKey): Promise<boolean> {
   const data = encoder.encode(JSON.stringify(payload))
-  const signature = Buffer.from(sig, 'base64url')
+  const signature = base64UrlToBytes(sig)
   return subtle.verify({ name: 'ECDSA', hash: 'SHA-256' }, key, signature, data)
 }
 

--- a/src/certs/betCert.ts
+++ b/src/certs/betCert.ts
@@ -1,3 +1,5 @@
+import { bytesToBase64Url, base64UrlToBytes } from '../utils/base64'
+
 const subtle = globalThis.crypto.subtle
 const encoder = new TextEncoder()
 
@@ -19,12 +21,12 @@ export interface BetCert extends BetCertPayload {
 async function signPayload(payload: BetCertPayload, key: CryptoKey): Promise<string> {
   const data = encoder.encode(JSON.stringify(payload))
   const sig = await subtle.sign({ name: 'ECDSA', hash: 'SHA-256' }, key, data)
-  return Buffer.from(sig).toString('base64url')
+  return bytesToBase64Url(new Uint8Array(sig))
 }
 
 async function verifyPayload(payload: BetCertPayload, sig: string, key: CryptoKey): Promise<boolean> {
   const data = encoder.encode(JSON.stringify(payload))
-  const signature = Buffer.from(sig, 'base64url')
+  const signature = base64UrlToBytes(sig)
   return subtle.verify({ name: 'ECDSA', hash: 'SHA-256' }, key, signature, data)
 }
 

--- a/src/certs/houseCert.ts
+++ b/src/certs/houseCert.ts
@@ -1,3 +1,5 @@
+import { bytesToBase64Url, base64UrlToBytes } from '../utils/base64'
+
 const subtle = globalThis.crypto.subtle
 
 export interface HouseCertPayload {
@@ -18,12 +20,12 @@ const encoder = new TextEncoder()
 async function signPayload(payload: any, key: CryptoKey): Promise<string> {
   const data = encoder.encode(JSON.stringify(payload))
   const sig = await subtle.sign({ name: 'ECDSA', hash: 'SHA-256' }, key, data)
-  return Buffer.from(sig).toString('base64url')
+  return bytesToBase64Url(new Uint8Array(sig))
 }
 
 async function verifyPayload(payload: any, signature: string, key: CryptoKey): Promise<boolean> {
   const data = encoder.encode(JSON.stringify(payload))
-  const sig = Buffer.from(signature, 'base64url')
+  const sig = base64UrlToBytes(signature)
   return subtle.verify({ name: 'ECDSA', hash: 'SHA-256' }, key, sig, data)
 }
 


### PR DESCRIPTION
## Summary
- use base64Url helpers in bet, bank receipt, and house cert modules
- ensure `subtle.verify` always receives Uint8Array inputs

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68ae4a3cb6dc8322beae9314ee25c51d