### PR TITLE
refactor: unify cert base64 encoding

### DIFF
--- a/src/certs/bankReceipt.ts
+++ b/src/certs/bankReceipt.ts
@@ -1,3 +1,5 @@
+import { bytesToBase64Url, base64UrlToBytes } from '../utils/base64'
+
 const subtle = globalThis.crypto.subtle
 const encoder = new TextEncoder()
 
@@ -20,12 +22,12 @@ export interface BankReceipt extends BankReceiptPayload {
 async function signPayload(payload: BankReceiptPayload, key: CryptoKey): Promise<string> {
   const data = encoder.encode(JSON.stringify(payload))
   const sig = await subtle.sign({ name: 'ECDSA', hash: 'SHA-256' }, key, data)
-  return Buffer.from(sig).toString('base64url')
+  return bytesToBase64Url(new Uint8Array(sig))
 }
 
 async function verifyPayload(payload: BankReceiptPayload, sig: string, key: CryptoKey): Promise<boolean> {
   const data = encoder.encode(JSON.stringify(payload))
-  const signature = Buffer.from(sig, 'base64url')
+  const signature = base64UrlToBytes(sig)
   return subtle.verify({ name: 'ECDSA', hash: 'SHA-256' }, key, signature, data)
 }
 

--- a/src/certs/betCert.ts
+++ b/src/certs/betCert.ts
@@ -1,3 +1,5 @@
+import { bytesToBase64Url, base64UrlToBytes } from '../utils/base64'
+
 const subtle = globalThis.crypto.subtle
 const encoder = new TextEncoder()
 
@@ -19,12 +21,12 @@ export interface BetCert extends BetCertPayload {
 async function signPayload(payload: BetCertPayload, key: CryptoKey): Promise<string> {
   const data = encoder.encode(JSON.stringify(payload))
   const sig = await subtle.sign({ name: 'ECDSA', hash: 'SHA-256' }, key, data)
-  return Buffer.from(sig).toString('base64url')
+  return bytesToBase64Url(new Uint8Array(sig))
 }
 
 async function verifyPayload(payload: BetCertPayload, sig: string, key: CryptoKey): Promise<boolean> {
   const data = encoder.encode(JSON.stringify(payload))
-  const signature = Buffer.from(sig, 'base64url')
+  const signature = base64UrlToBytes(sig)
   return subtle.verify({ name: 'ECDSA', hash: 'SHA-256' }, key, signature, data)
 }
 

--- a/src/certs/houseCert.ts
+++ b/src/certs/houseCert.ts
@@ -1,3 +1,5 @@
+import { bytesToBase64Url, base64UrlToBytes } from '../utils/base64'
+
 const subtle = globalThis.crypto.subtle
 
 export interface HouseCertPayload {
@@ -18,12 +20,12 @@ const encoder = new TextEncoder()
 async function signPayload(payload: any, key: CryptoKey): Promise<string> {
   const data = encoder.encode(JSON.stringify(payload))
   const sig = await subtle.sign({ name: 'ECDSA', hash: 'SHA-256' }, key, data)
-  return Buffer.from(sig).toString('base64url')
+  return bytesToBase64Url(new Uint8Array(sig))
 }
 
 async function verifyPayload(payload: any, signature: string, key: CryptoKey): Promise<boolean> {
   const data = encoder.encode(JSON.stringify(payload))
-  const sig = Buffer.from(signature, 'base64url')
+  const sig = base64UrlToBytes(signature)
   return subtle.verify({ name: 'ECDSA', hash: 'SHA-256' }, key, sig, data)
 }
 


### PR DESCRIPTION
## Summary
- replace Buffer-based cert encoding with shared base64 helpers
- ensure signatures convert with bytesToBase64Url/base64UrlToBytes across cert modules

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae59f82aa48322890b29ca30a85e38