### PR TITLE
Document base64url encoding for signatures

### DIFF
--- a/docs/bank_receipt_contract.md
+++ b/docs/bank_receipt_contract.md
@@ -46,11 +46,14 @@ Receipts can be exported or transferred as a JSON payload encoded into a QR:
   "nbf": "<epoch ms>",
   "exp": "<optional epoch ms>",
   "spent": false,
-  "betCertRef": "<bet cert id>"
+  "betCertRef": "<bet cert id>",
+  "sig": "<house signature>"
 }
 ```
 
 `betCertRef` links the receipt back to the [Bet Certificate](./bet_certificate_contract.md) that produced the settlement. The `exp` field (if present) governs when the receipt must be renewed.
+
+The `sig` field is the House's signature over the payload. Signature bytes are base64url‑encoded using the shared helper functions in `src/utils/base64.ts` (`bytesToBase64Url` / `base64UrlToBytes`), which work in both browser and Node environments.
 
 ## Usage Paths
 - **Re-buy into round:** Player presents receipt; House verifies validity and converts value into the 4-credit round entry at the declared valuation (up to 8 credits cap). Any leftover remains stored.

--- a/docs/bet_certificate_contract.md
+++ b/docs/bet_certificate_contract.md
@@ -43,11 +43,14 @@ Bet Certs may be exported as a compact JSON object encoded into a QR for portabi
   "betHash": "<sha256>",
   "nbf": "<epoch ms>",
   "exp": "<epoch ms>",
-  "bankRef": "<optional receiptId>"
+  "bankRef": "<optional receiptId>",
+  "sig": "<house signature>"
 }
 ```
 
 `bankRef` links back to the funding [BANK Receipt](./bank_receipt_contract.md) if one was used. The `exp` value sets the short TTL; after expiry the Player must renew for a read‑only view.
+
+The `sig` field contains the House's signature over the payload. Signature bytes are base64url‑encoded using the shared helper functions in `src/utils/base64.ts` (`bytesToBase64Url` / `base64UrlToBytes`), which support both browser and Node environments.
 
 ## Renewal
 - **Purpose:** Allow Player to continue reopening a locked bet beyond initial short TTL.

--- a/docs/house_certificate_contract.md
+++ b/docs/house_certificate_contract.md
@@ -9,6 +9,8 @@ Authorize a device/operator to run **House** features for Roll‑et. Enables hos
 - **House Device(s):** Hold the private key corresponding to the public key attested in the Cert.
 - **Players:** Verify the Cert offline before joining a round.
 
+`HouseCert` is structured as a payload plus a `signature` field. The signature bytes are base64url‑encoded using the shared helpers in `src/utils/base64.ts` (`bytesToBase64Url` / `base64UrlToBytes`), which support both browsers and Node (via `btoa`/`atob` or Node's `Buffer`).
+
 ## Lifecycle & States
 1. **Issue** (monetized): Cert created after purchase/entitlement check.
 2. **Active:** Within validity window; grants hosting capabilities.

--- a/docs/join_challenge_response_contract.md
+++ b/docs/join_challenge_response_contract.md
@@ -45,6 +45,8 @@ Provide a secure, offline-verifiable admission mechanism for Players to join a H
 
 `bankRef` allows a Player to fund the buy-in with a stored [BANK Receipt](./bank_receipt_contract.md). When admission succeeds, this `bankRef` is logged and later embedded in the resulting [Bet Certificate](./bet_certificate_contract.md).
 
+All binary values—the House certificate's `signature`, the challenge `nonce`, the response `hmac`, and the Player `sig`—are base64url-encoded. Developers should use the shared helpers in `src/utils/base64.ts` (`bytesToBase64Url` / `base64UrlToBytes`) to handle these fields. The utilities abstract away environment differences by using browser `btoa`/`atob` when available and falling back to Node's `Buffer` APIs so the same code works across platforms.
+
 ## Challenge Requirements
 - **Contents:**  
   - House Certificate  

--- a/src/certs/bankReceipt.ts
+++ b/src/certs/bankReceipt.ts
@@ -1,3 +1,5 @@
+import { bytesToBase64Url, base64UrlToBytes } from '../utils/base64'
+
 const subtle = globalThis.crypto.subtle
 const encoder = new TextEncoder()
 
@@ -20,12 +22,12 @@ export interface BankReceipt extends BankReceiptPayload {
 async function signPayload(payload: BankReceiptPayload, key: CryptoKey): Promise<string> {
   const data = encoder.encode(JSON.stringify(payload))
   const sig = await subtle.sign({ name: 'ECDSA', hash: 'SHA-256' }, key, data)
-  return Buffer.from(sig).toString('base64url')
+  return bytesToBase64Url(new Uint8Array(sig))
 }
 
 async function verifyPayload(payload: BankReceiptPayload, sig: string, key: CryptoKey): Promise<boolean> {
   const data = encoder.encode(JSON.stringify(payload))
-  const signature = Buffer.from(sig, 'base64url')
+  const signature = base64UrlToBytes(sig) as Uint8Array<ArrayBuffer>
   return subtle.verify({ name: 'ECDSA', hash: 'SHA-256' }, key, signature, data)
 }
 

--- a/src/certs/betCert.ts
+++ b/src/certs/betCert.ts
@@ -1,3 +1,5 @@
+import { bytesToBase64Url, base64UrlToBytes } from '../utils/base64'
+
 const subtle = globalThis.crypto.subtle
 const encoder = new TextEncoder()
 
@@ -19,12 +21,12 @@ export interface BetCert extends BetCertPayload {
 async function signPayload(payload: BetCertPayload, key: CryptoKey): Promise<string> {
   const data = encoder.encode(JSON.stringify(payload))
   const sig = await subtle.sign({ name: 'ECDSA', hash: 'SHA-256' }, key, data)
-  return Buffer.from(sig).toString('base64url')
+  return bytesToBase64Url(new Uint8Array(sig))
 }
 
 async function verifyPayload(payload: BetCertPayload, sig: string, key: CryptoKey): Promise<boolean> {
   const data = encoder.encode(JSON.stringify(payload))
-  const signature = Buffer.from(sig, 'base64url')
+  const signature = base64UrlToBytes(sig) as Uint8Array<ArrayBuffer>
   return subtle.verify({ name: 'ECDSA', hash: 'SHA-256' }, key, signature, data)
 }
 

--- a/src/certs/houseCert.ts
+++ b/src/certs/houseCert.ts
@@ -1,3 +1,5 @@
+import { bytesToBase64Url, base64UrlToBytes } from '../utils/base64'
+
 const subtle = globalThis.crypto.subtle
 
 export interface HouseCertPayload {
@@ -18,12 +20,12 @@ const encoder = new TextEncoder()
 async function signPayload(payload: any, key: CryptoKey): Promise<string> {
   const data = encoder.encode(JSON.stringify(payload))
   const sig = await subtle.sign({ name: 'ECDSA', hash: 'SHA-256' }, key, data)
-  return Buffer.from(sig).toString('base64url')
+  return bytesToBase64Url(new Uint8Array(sig))
 }
 
 async function verifyPayload(payload: any, signature: string, key: CryptoKey): Promise<boolean> {
   const data = encoder.encode(JSON.stringify(payload))
-  const sig = Buffer.from(signature, 'base64url')
+  const sig = base64UrlToBytes(signature) as Uint8Array<ArrayBuffer>
   return subtle.verify({ name: 'ECDSA', hash: 'SHA-256' }, key, sig, data)
 }
 

--- a/src/utils/base64.ts
+++ b/src/utils/base64.ts
@@ -1,19 +1,29 @@
-export function bytesToBase64Url(bytes: Uint8Array): string {
-  let binary = ''
-  for (const b of bytes) {
-    binary += String.fromCharCode(b)
+function base64FromBytes(bytes: Uint8Array): string {
+  if (typeof btoa === 'function') {
+    let binary = ''
+    for (const b of bytes) binary += String.fromCharCode(b)
+    return btoa(binary)
   }
-  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '')
+  return Buffer.from(bytes).toString('base64')
+}
+
+function bytesFromBase64(base64: string): Uint8Array {
+  if (typeof atob === 'function') {
+    const binary = atob(base64)
+    const bytes = new Uint8Array(binary.length)
+    for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i)
+    return bytes
+  }
+  return Uint8Array.from(Buffer.from(base64, 'base64'))
+}
+
+export function bytesToBase64Url(bytes: Uint8Array): string {
+  return base64FromBytes(bytes).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '')
 }
 
 export function base64UrlToBytes(base64url: string): Uint8Array {
   const base64 = base64url.replace(/-/g, '+').replace(/_/g, '/')
   const padLength = (4 - (base64.length % 4)) % 4
   const padded = base64 + '='.repeat(padLength)
-  const binary = atob(padded)
-  const bytes = new Uint8Array(binary.length)
-  for (let i = 0; i < binary.length; i++) {
-    bytes[i] = binary.charCodeAt(i)
-  }
-  return bytes
+  return bytesFromBase64(padded)
 }


### PR DESCRIPTION
## Summary
- detail that signatures and HMACs use shared base64url helpers with browser/Node fallbacks
- refactor cert helpers to use the cross-env base64 utilities

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af3869e3c88322927ab0321e60caab