### PR TITLE
Run jsdom and node tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,11 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Run tests
+      - name: Run jsdom tests
         run: npm test
+
+      - name: Run node tests
+        run: npm run test:node
 
       - name: Build
         run: npm run build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,5 +22,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Run tests
+      - name: Run jsdom tests
         run: npm test
+
+      - name: Run node tests
+        run: npm run test:node

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview --port 5173",
-    "test": "vitest --environment jsdom"
+    "test": "vitest --environment jsdom",
+    "test:node": "vitest run --environment node src/__tests__/*.test.ts"
   },
   "dependencies": {
     "qrcode": "^1.5.4",


### PR DESCRIPTION
## Summary
- add dedicated Node test script
- run jsdom and node test suites in CI workflows

## Testing
- `CI=1 npm test`
- `CI=1 npm run test:node`


------
https://chatgpt.com/codex/tasks/task_e_68af472c511483229fccf59ee623575d