### PR TITLE
feat: add jsqr fallback for join scanner

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "roll-et",
       "version": "0.1.0",
       "dependencies": {
+        "jsqr": "^1.4.0",
         "qrcode": "^1.5.4",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -6169,6 +6170,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/jsqr": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsqr/-/jsqr-1.4.0.tgz",
+      "integrity": "sha512-dxLob7q65Xg2DvstYkRpkYtmKm2sPJ9oFhrhmudT1dZvNFFTlroai3AWSpLey/w5vMcLBXRgOJsbXpdN9HzU/A==",
+      "license": "Apache-2.0"
     },
     "node_modules/leven": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test:node": "vitest run --environment node src/__tests__/*.test.ts"
   },
   "dependencies": {
+    "jsqr": "^1.4.0",
     "qrcode": "^1.5.4",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",


### PR DESCRIPTION
## Summary
- add jsqr dependency and fallback when `BarcodeDetector` is unavailable
- capture video frames on a canvas and decode via jsQR, reusing existing join response logic

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68af51326a70832285bbc939f784de51