### PR TITLE
feat: add bet cert scanner

### DIFF
--- a/src/Player.tsx
+++ b/src/Player.tsx
@@ -5,6 +5,8 @@ import { fmtUSD, fmtUSDSign } from './utils'
 import { getOdds } from './game/engine'
 import type { Bet } from './game/engine'
 import { useInstallPrompt } from './pwa/useInstallPrompt'
+import BetCertScanner from './components/BetCertScanner'
+import type { BetCert } from './certs/betCert'
 
 function describeBet(b: Bet): string {
   switch (b.type) {
@@ -32,6 +34,8 @@ function potential(b: Bet): number {
 export default function Player() {
   const { players } = usePlayers()
   const { canInstall, install, installed } = useInstallPrompt()
+  const [scanning, setScanning] = React.useState(false)
+  const [lastCert, setLastCert] = React.useState<BetCert | null>(null)
 
   return (
     <div className="container">
@@ -40,6 +44,23 @@ export default function Player() {
         <h1>Player Summary</h1>
         <div className="right" />
       </header>
+
+      <section className="controls">
+        <button onClick={() => setScanning(true)}>Scan Bet Cert</button>
+      </section>
+
+      {scanning && (
+        <section className="bets">
+          <BetCertScanner onCert={cert => { setLastCert(cert); setScanning(false) }} />
+        </section>
+      )}
+
+      {lastCert && (
+        <section className="bets">
+          <h3>Last Bet Cert</h3>
+          <pre>{JSON.stringify(lastCert, null, 2)}</pre>
+        </section>
+      )}
 
       <section className="bets">
         {players.map(p => (

--- a/src/components/BetCertScanner.tsx
+++ b/src/components/BetCertScanner.tsx
@@ -1,0 +1,96 @@
+import React from 'react'
+import jsQR from 'jsqr'
+import { parseBetCert } from '../betCertQR'
+import type { BetCert } from '../certs/betCert'
+
+interface BetCertScannerProps {
+  onCert: (cert: BetCert) => void
+}
+
+export default function BetCertScanner({ onCert }: BetCertScannerProps) {
+  const videoRef = React.useRef<HTMLVideoElement>(null)
+  const streamRef = React.useRef<MediaStream | null>(null)
+  const detectorRef = React.useRef<any>(null)
+  const canvasRef = React.useRef<HTMLCanvasElement | null>(null)
+  const [error, setError] = React.useState<string | null>(null)
+
+  React.useEffect(() => {
+    let cancelled = false
+    async function init() {
+      try {
+        const stream = await navigator.mediaDevices.getUserMedia({ video: { facingMode: 'environment' } })
+        if (cancelled) return
+        streamRef.current = stream
+        if (videoRef.current) {
+          videoRef.current.srcObject = stream
+          await videoRef.current.play()
+          requestAnimationFrame(scan)
+        }
+      } catch (e) {
+        setError('Unable to access camera')
+      }
+    }
+    init()
+    return () => {
+      cancelled = true
+      streamRef.current?.getTracks().forEach(t => t.stop())
+    }
+  }, [])
+
+  const scan = async () => {
+    if (!videoRef.current) {
+      requestAnimationFrame(scan)
+      return
+    }
+    if ('BarcodeDetector' in window) {
+      try {
+        if (!detectorRef.current) {
+          detectorRef.current = new (window as any).BarcodeDetector({ formats: ['qr_code'] })
+        }
+        const codes = await detectorRef.current.detect(videoRef.current)
+        if (codes.length > 0) {
+          handlePayload(codes[0].rawValue)
+          return
+        }
+      } catch (err) {
+        console.error(err)
+      }
+    } else {
+      if (!canvasRef.current) {
+        canvasRef.current = document.createElement('canvas')
+      }
+      const canvas = canvasRef.current
+      const video = videoRef.current
+      const ctx = canvas.getContext('2d')
+      if (ctx && video.videoWidth > 0 && video.videoHeight > 0) {
+        canvas.width = video.videoWidth
+        canvas.height = video.videoHeight
+        ctx.drawImage(video, 0, 0, canvas.width, canvas.height)
+        const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height)
+        const code = jsQR(imageData.data, canvas.width, canvas.height)
+        if (code) {
+          handlePayload(code.data)
+          return
+        }
+      }
+    }
+    requestAnimationFrame(scan)
+  }
+
+  const handlePayload = (raw: string) => {
+    try {
+      const cert = parseBetCert(raw)
+      onCert(cert)
+      streamRef.current?.getTracks().forEach(t => t.stop())
+    } catch (e) {
+      setError('Scan failed')
+    }
+  }
+
+  return (
+    <div>
+      <video ref={videoRef} style={{ width: '100%' }} />
+      {error && <div className="error">{error}</div>}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add BetCertScanner component to parse bet certificate QR codes
- allow players to scan Bet Certs and view last scanned certificate
- show Bet Cert QR codes on House page after locking a round

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af565b7dd0832297ae6331ff6a4510