### PR TITLE
Add bank receipt QR utilities and scanner

### DIFF
--- a/src/Player.tsx
+++ b/src/Player.tsx
@@ -6,7 +6,9 @@ import { getOdds } from './game/engine'
 import type { Bet } from './game/engine'
 import { useInstallPrompt } from './pwa/useInstallPrompt'
 import BetCertScanner from './components/BetCertScanner'
+import BankReceiptScanner from './components/BankReceiptScanner'
 import type { BetCert } from './certs/betCert'
+import type { BankReceipt } from './certs/bankReceipt'
 
 function describeBet(b: Bet): string {
   switch (b.type) {
@@ -34,8 +36,10 @@ function potential(b: Bet): number {
 export default function Player() {
   const { players } = usePlayers()
   const { canInstall, install, installed } = useInstallPrompt()
-  const [scanning, setScanning] = React.useState(false)
+  const [scanningCert, setScanningCert] = React.useState(false)
+  const [scanningReceipt, setScanningReceipt] = React.useState(false)
   const [lastCert, setLastCert] = React.useState<BetCert | null>(null)
+  const [lastReceipt, setLastReceipt] = React.useState<BankReceipt | null>(null)
 
   return (
     <div className="container">
@@ -46,12 +50,19 @@ export default function Player() {
       </header>
 
       <section className="controls">
-        <button onClick={() => setScanning(true)}>Scan Bet Cert</button>
+        <button onClick={() => setScanningCert(true)}>Scan Bet Cert</button>
+        <button onClick={() => setScanningReceipt(true)}>Scan Bank Receipt</button>
       </section>
 
-      {scanning && (
+      {scanningCert && (
         <section className="bets">
-          <BetCertScanner onCert={cert => { setLastCert(cert); setScanning(false) }} />
+          <BetCertScanner onCert={cert => { setLastCert(cert); setScanningCert(false) }} />
+        </section>
+      )}
+
+      {scanningReceipt && (
+        <section className="bets">
+          <BankReceiptScanner onReceipt={r => { setLastReceipt(r); setScanningReceipt(false) }} />
         </section>
       )}
 
@@ -59,6 +70,13 @@ export default function Player() {
         <section className="bets">
           <h3>Last Bet Cert</h3>
           <pre>{JSON.stringify(lastCert, null, 2)}</pre>
+        </section>
+      )}
+
+      {lastReceipt && (
+        <section className="bets">
+          <h3>Last Bank Receipt</h3>
+          <pre>{JSON.stringify(lastReceipt, null, 2)}</pre>
         </section>
       )}
 

--- a/src/__tests__/qr.test.ts
+++ b/src/__tests__/qr.test.ts
@@ -2,13 +2,15 @@ import { describe, it, expect } from 'vitest'
 import { issueHouseCert } from '../certs/houseCert'
 import { createJoinChallenge, joinChallengeToQR, parseJoinChallenge, validateJoinChallenge } from '../join'
 import { betCertToQR, parseBetCert } from '../betCertQR'
+import { bankReceiptToQR, parseBankReceipt } from '../bankReceiptQR'
 import { generateBetCert } from '../certs/betCert'
+import { issueBankReceipt } from '../certs/bankReceipt'
 
 function subtle() { return globalThis.crypto.subtle }
 async function genKeyPair() { return subtle().generateKey({ name: 'ECDSA', namedCurve: 'P-256' }, true, ['sign','verify']) }
 
 describe('QR flows', () => {
-  it('creates join challenge QR and bet cert QR', async () => {
+  it('creates join challenge QR, bet cert QR, and bank receipt QR', async () => {
     const root = await genKeyPair()
     const house = await genKeyPair()
     const houseCert = await issueHouseCert({
@@ -36,5 +38,19 @@ describe('QR flows', () => {
     expect(betQR.startsWith('data:image/png;base64')).toBe(true)
     const parsedBet = parseBetCert(JSON.stringify(betCert))
     expect(parsedBet.certId).toBe(betCert.certId)
+
+    const receipt = await issueBankReceipt({
+      receiptId: 'rec1',
+      player: 'p1',
+      round: 'r1',
+      value: 10,
+      nbf: Date.now() - 1000,
+      exp: Date.now() + 60_000,
+      betCertRef: betCert.certId,
+    }, house.privateKey)
+    const receiptQR = await bankReceiptToQR(receipt)
+    expect(receiptQR.startsWith('data:image/png;base64')).toBe(true)
+    const parsedReceipt = parseBankReceipt(JSON.stringify(receipt))
+    expect(parsedReceipt.receiptId).toBe(receipt.receiptId)
   })
 })

--- a/src/bankReceiptQR.ts
+++ b/src/bankReceiptQR.ts
@@ -1,0 +1,10 @@
+import QRCode from 'qrcode'
+import type { BankReceipt } from './certs/bankReceipt'
+
+export async function bankReceiptToQR(receipt: BankReceipt): Promise<string> {
+  return QRCode.toDataURL(JSON.stringify(receipt))
+}
+
+export function parseBankReceipt(str: string): BankReceipt {
+  return JSON.parse(str) as BankReceipt
+}

--- a/src/components/BankReceiptScanner.tsx
+++ b/src/components/BankReceiptScanner.tsx
@@ -1,0 +1,96 @@
+import React from 'react'
+import jsQR from 'jsqr'
+import { parseBankReceipt } from '../bankReceiptQR'
+import type { BankReceipt } from '../certs/bankReceipt'
+
+interface BankReceiptScannerProps {
+  onReceipt: (receipt: BankReceipt) => void
+}
+
+export default function BankReceiptScanner({ onReceipt }: BankReceiptScannerProps) {
+  const videoRef = React.useRef<HTMLVideoElement>(null)
+  const streamRef = React.useRef<MediaStream | null>(null)
+  const detectorRef = React.useRef<any>(null)
+  const canvasRef = React.useRef<HTMLCanvasElement | null>(null)
+  const [error, setError] = React.useState<string | null>(null)
+
+  React.useEffect(() => {
+    let cancelled = false
+    async function init() {
+      try {
+        const stream = await navigator.mediaDevices.getUserMedia({ video: { facingMode: 'environment' } })
+        if (cancelled) return
+        streamRef.current = stream
+        if (videoRef.current) {
+          videoRef.current.srcObject = stream
+          await videoRef.current.play()
+          requestAnimationFrame(scan)
+        }
+      } catch (e) {
+        setError('Unable to access camera')
+      }
+    }
+    init()
+    return () => {
+      cancelled = true
+      streamRef.current?.getTracks().forEach(t => t.stop())
+    }
+  }, [])
+
+  const scan = async () => {
+    if (!videoRef.current) {
+      requestAnimationFrame(scan)
+      return
+    }
+    if ('BarcodeDetector' in window) {
+      try {
+        if (!detectorRef.current) {
+          detectorRef.current = new (window as any).BarcodeDetector({ formats: ['qr_code'] })
+        }
+        const codes = await detectorRef.current.detect(videoRef.current)
+        if (codes.length > 0) {
+          handlePayload(codes[0].rawValue)
+          return
+        }
+      } catch (err) {
+        console.error(err)
+      }
+    } else {
+      if (!canvasRef.current) {
+        canvasRef.current = document.createElement('canvas')
+      }
+      const canvas = canvasRef.current
+      const video = videoRef.current
+      const ctx = canvas.getContext('2d')
+      if (ctx && video.videoWidth > 0 && video.videoHeight > 0) {
+        canvas.width = video.videoWidth
+        canvas.height = video.videoHeight
+        ctx.drawImage(video, 0, 0, canvas.width, canvas.height)
+        const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height)
+        const code = jsQR(imageData.data, canvas.width, canvas.height)
+        if (code) {
+          handlePayload(code.data)
+          return
+        }
+      }
+    }
+    requestAnimationFrame(scan)
+  }
+
+  const handlePayload = (raw: string) => {
+    try {
+      const receipt = parseBankReceipt(raw)
+      onReceipt(receipt)
+      streamRef.current?.getTracks().forEach(t => t.stop())
+    } catch (e) {
+      setError('Scan failed')
+    }
+  }
+
+  return (
+    <div>
+      <video ref={videoRef} style={{ width: '100%' }} />
+      {error && <div className="error">{error}</div>}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add BankReceipt QR encode/decode helpers
- support scanning bank receipt QRs in Player view
- cover bank receipt QR flow in tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af5afb605c83228052e8e4c4664ae2