### PR TITLE
docs: document QR helpers and scanning fallback

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -18,3 +18,9 @@ This directory collects design and contract specifications for Roll-et, an offli
 4. [Ledger & Sync](ledger_sync_contract.md) – records every admission, certificate and receipt, enforcing the game's $1,440/player/round ceiling during sync.
 
 These documents describe how each step chains to the next: [Join Challenge/Response](join_challenge_response_contract.md) → [Bet Certificate](bet_certificate_contract.md) → [BANK Receipt](bank_receipt_contract.md), all anchored by the [House Certificate](house_certificate_contract.md) and recorded in the [Ledger & Sync](ledger_sync_contract.md).
+
+## QR Helpers & Scanning
+Roll‑et uses QRs to move join challenges, Bet Certs and BANK Receipts between devices. Helper modules and components provide a consistent experience:
+
+- [`betCertQR.ts`](../src/betCertQR.ts) & [`bankReceiptQR.ts`](../src/bankReceiptQR.ts) generate data URL images and parse payloads for Bet Certs and BANK Receipts.
+- Scanner components such as [`BetCertScanner`](../src/components/BetCertScanner.tsx) and [`BankReceiptScanner`](../src/components/BankReceiptScanner.tsx) attempt the browser `BarcodeDetector` API (Chrome ≥83, Edge ≥83, Opera ≥70, Android WebView ≥88) with a [`jsQR`](https://github.com/cozmo/jsQR) fallback for browsers lacking support.

--- a/docs/bank_receipt_contract.md
+++ b/docs/bank_receipt_contract.md
@@ -55,6 +55,10 @@ Receipts can be exported or transferred as a JSON payload encoded into a QR:
 
 The `sig` field is the House's signature over the payload. Signature bytes are base64url‑encoded using the shared helper functions in `src/utils/base64.ts` (`bytesToBase64Url` / `base64UrlToBytes`), which work in both browser and Node environments.
 
+## QR Generation & Scanning
+- BANK Receipts may be exported or transported as QR codes using [`bankReceiptQR.ts`](../src/bankReceiptQR.ts), which includes helpers for creating data URL images and parsing scanned payloads.
+- The [`BankReceiptScanner`](../src/components/BankReceiptScanner.tsx) component reads receipt QRs. It attempts the native `BarcodeDetector` API first (Chrome ≥83, Edge ≥83, Opera ≥70, Android WebView ≥88) and falls back to [`jsQR`](https://github.com/cozmo/jsQR) via canvas capture for Safari, Firefox and older Chromium releases.
+
 ## Usage Paths
 - **Re-buy into round:** Player presents receipt; House verifies validity and converts value into the 4-credit round entry at the declared valuation (up to 8 credits cap). Any leftover remains stored.
 - **Withdraw (tender):** Player presents receipt; House verifies and pays out; marks receipt “spent.”

--- a/docs/bet_certificate_contract.md
+++ b/docs/bet_certificate_contract.md
@@ -52,6 +52,10 @@ Bet Certs may be exported as a compact JSON object encoded into a QR for portabi
 
 The `sig` field contains the House's signature over the payload. Signature bytes are base64url‑encoded using the shared helper functions in `src/utils/base64.ts` (`bytesToBase64Url` / `base64UrlToBytes`), which support both browser and Node environments.
 
+## QR Generation & Scanning
+- Bet Cert payloads can be exported or shared as QR images using [`betCertQR.ts`](../src/betCertQR.ts), which provides helpers for generating data URLs and parsing scanned strings.
+- The [`BetCertScanner`](../src/components/BetCertScanner.tsx) component reads Bet Cert QRs. It prefers the native `BarcodeDetector` API (Chrome ≥83, Edge ≥83, Opera ≥70, Android WebView ≥88) and falls back to [`jsQR`](https://github.com/cozmo/jsQR) via a canvas capture when the API is unavailable (Safari, Firefox, older Chromium).
+
 ## Renewal
 - **Purpose:** Allow Player to continue reopening a locked bet beyond initial short TTL.
 - **Mechanism:** Player presents expired Cert (QR or stored payload) to House; House verifies ledger state and issues a fresh Cert with an updated `exp` while keeping the original `certId` and `bankRef`.

--- a/docs/join_challenge_response_contract.md
+++ b/docs/join_challenge_response_contract.md
@@ -47,6 +47,11 @@ Provide a secure, offline-verifiable admission mechanism for Players to join a H
 
 All binary values—the House certificate's `signature`, the challenge `nonce`, the response `hmac`, and the Player `sig`—are base64url-encoded. Developers should use the shared helpers in `src/utils/base64.ts` (`bytesToBase64Url` / `base64UrlToBytes`) to handle these fields. The utilities abstract away environment differences by using browser `btoa`/`atob` when available and falling back to Node's `Buffer` APIs so the same code works across platforms.
 
+## QR Generation & Scanning
+- Join challenges, [Bet Certificates](./bet_certificate_contract.md) and [BANK Receipts](./bank_receipt_contract.md) can be rendered as QRs for portability. Helper modules in [`betCertQR.ts`](../src/betCertQR.ts) and [`bankReceiptQR.ts`](../src/bankReceiptQR.ts) generate data URL images and parse scanned payloads.
+- Scanning leverages the browser `BarcodeDetector` API when supported (Chrome ≥83, Edge ≥83, Opera ≥70, Android WebView ≥88). Browsers without support (Safari, Firefox, older Chromium) fall back to [`jsQR`](https://github.com/cozmo/jsQR) using a canvas capture.
+- The [`BetCertScanner`](../src/components/BetCertScanner.tsx) and [`BankReceiptScanner`](../src/components/BankReceiptScanner.tsx) components implement this detection flow for Bet Certs and BANK Receipts respectively.
+
 ## Challenge Requirements
 - **Contents:**  
   - House Certificate  


### PR DESCRIPTION
## Summary
- document QR generation and scanning helpers for Bet Certs and BANK Receipts
- note BarcodeDetector support with jsQR fallback
- link to BetCertScanner and bankReceiptQR utilities

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af67213d5c832286ddcdef9760616d