### PR TITLE
Add join response verification and tests

### DIFF
--- a/src/__tests__/join.test.ts
+++ b/src/__tests__/join.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest'
+import { createJoinChallenge, createJoinResponse, verifyJoinResponse } from '../join'
+
+const subtle = globalThis.crypto.subtle
+
+async function genHmacKey() {
+  return subtle.generateKey({ name: 'HMAC', hash: 'SHA-256' }, true, ['sign', 'verify'])
+}
+
+async function genPlayerKeys() {
+  return subtle.generateKey({ name: 'ECDSA', namedCurve: 'P-256' }, true, ['sign', 'verify'])
+}
+
+describe('verifyJoinResponse', () => {
+  it('accepts a valid response', async () => {
+    const houseCert: any = { payload: {}, signature: '' }
+    const challenge = await createJoinChallenge(houseCert, 'r1')
+    const secret = await genHmacKey()
+    const playerKeys = await genPlayerKeys()
+    const response = await createJoinResponse('player1', challenge, secret, playerKeys.privateKey)
+    expect(await verifyJoinResponse(response, challenge, secret, playerKeys.publicKey)).toBe(true)
+  })
+
+  it('rejects when challenge fields mismatch', async () => {
+    const houseCert: any = { payload: {}, signature: '' }
+    const challenge = await createJoinChallenge(houseCert, 'r1')
+    const secret = await genHmacKey()
+    const playerKeys = await genPlayerKeys()
+    const response = await createJoinResponse('player1', challenge, secret, playerKeys.privateKey)
+    const badChallenge = { ...challenge, nonce: challenge.nonce + 'x' }
+    expect(await verifyJoinResponse(response, badChallenge, secret, playerKeys.publicKey)).toBe(false)
+  })
+
+  it('rejects with invalid hmac', async () => {
+    const houseCert: any = { payload: {}, signature: '' }
+    const challenge = await createJoinChallenge(houseCert, 'r1')
+    const secret = await genHmacKey()
+    const wrongSecret = await genHmacKey()
+    const playerKeys = await genPlayerKeys()
+    const response = await createJoinResponse('player1', challenge, secret, playerKeys.privateKey)
+    expect(await verifyJoinResponse(response, challenge, wrongSecret, playerKeys.publicKey)).toBe(false)
+  })
+
+  it('rejects with invalid signature', async () => {
+    const houseCert: any = { payload: {}, signature: '' }
+    const challenge = await createJoinChallenge(houseCert, 'r1')
+    const secret = await genHmacKey()
+    const playerKeys = await genPlayerKeys()
+    const otherKeys = await genPlayerKeys()
+    const response = await createJoinResponse('player1', challenge, secret, playerKeys.privateKey)
+    expect(await verifyJoinResponse(response, challenge, secret, otherKeys.publicKey)).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- add `verifyJoinResponse` to validate incoming join responses
- test join response verification for valid and invalid scenarios

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68af70b73c54832292661c6ee59874c8