### PR TITLE
Validate host cert before entering house mode

### DIFF
--- a/src/certs/authorizedHouseCertLedger.ts
+++ b/src/certs/authorizedHouseCertLedger.ts
@@ -1,0 +1,22 @@
+import { HouseCert } from './houseCert'
+
+export interface AuthorizedHouseCertLedgerEntry {
+  subject: string
+  signature: string
+}
+
+export const authorizedHouseCertLedger: AuthorizedHouseCertLedgerEntry[] = []
+
+export const houseCertRootPublicKeyJwk: JsonWebKey = {
+  kty: 'EC',
+  crv: 'P-256',
+  x: 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+  y: 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+  ext: true,
+}
+
+export function isAuthorizedHouseCert(cert: HouseCert): boolean {
+  return authorizedHouseCertLedger.some(
+    entry => entry.subject === cert.payload.subject && entry.signature === cert.signature
+  )
+}


### PR DESCRIPTION
## Summary
- Add `authorizedHouseCertLedger` module with ledger and helper to verify whether a house certificate is authorized
- Replace host link on landing page with button that checks stored certificate, validates it against root key and ledger, and routes accordingly

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68b186f172108322a80514ff70d8ce90