### PR TITLE
test: mock localStorage in ledger tests

### DIFF
--- a/src/__tests__/ledger.test.ts
+++ b/src/__tests__/ledger.test.ts
@@ -1,6 +1,20 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import { appendLedger, getLedger, getUnsyncedEntries, markSynced } from '../ledger/localLedger'
 
+const store: Record<string, string> = {}
+const localStorageMock = {
+  getItem(key: string) {
+    return Object.prototype.hasOwnProperty.call(store, key) ? store[key] : null
+  },
+  setItem(key: string, value: string) {
+    store[key] = value
+  },
+  removeItem(key: string) {
+    delete store[key]
+  },
+}
+;(globalThis as any).localStorage = localStorageMock
+
 describe('local ledger', () => {
   beforeEach(() => {
     localStorage.removeItem('roll_et_ledger_v1')


### PR DESCRIPTION
## Summary
- add in-memory localStorage mock for ledger tests

## Testing
- `npm run test:node`


------
https://chatgpt.com/codex/tasks/task_e_68b2e20989948322a4acb774fb8baace