### PR TITLE
Expose onResponseEx in JoinScanner props

### DIFF
--- a/src/components/JoinScanner.tsx
+++ b/src/components/JoinScanner.tsx
@@ -11,7 +11,14 @@ interface JoinScannerProps {
   onResponseEx?: (resp: JoinResponse, challenge: ReturnType<typeof parseJoinChallenge>) => void
 }
 
-export default function JoinScanner({ playerId, playerKey, playerSecret, rootKey, onResponse }: JoinScannerProps) {
+export default function JoinScanner({
+  playerId,
+  playerKey,
+  playerSecret,
+  rootKey,
+  onResponse,
+  onResponseEx
+}: JoinScannerProps) {
   const videoRef = React.useRef<HTMLVideoElement>(null)
   const streamRef = React.useRef<MediaStream | null>(null)
   const detectorRef = React.useRef<any>(null)


### PR DESCRIPTION
## Summary
- Destructure optional `onResponseEx` callback in `JoinScanner` component

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b2e588969c83229c7237a7adddbcfc