### PR TITLE
refactor: import hmac key as arraybuffer

### DIFF
--- a/src/utils/totp.ts
+++ b/src/utils/totp.ts
@@ -3,7 +3,13 @@
 const encoder = new TextEncoder()
 
 async function hmacSha256(keyBytes: Uint8Array, msg: string): Promise<Uint8Array> {
-  const key = await crypto.subtle.importKey('raw', keyBytes, { name: 'HMAC', hash: 'SHA-256' }, false, ['sign'])
+  const key = await crypto.subtle.importKey(
+    'raw',
+    keyBytes.buffer as ArrayBuffer,
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign']
+  )
   const sig = await crypto.subtle.sign('HMAC', key, encoder.encode(msg))
   return new Uint8Array(sig)
 }


### PR DESCRIPTION
## Summary
- ensure hmacSha256 imports key as ArrayBuffer
- keep return value as Uint8Array

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68b2e717afa48322b3a60d13ffe43f90