### PR TITLE
Add real tests for BetBoard component and utilities

### DIFF
--- a/src/__tests__/BetBoard.test.tsx
+++ b/src/__tests__/BetBoard.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+import { describe, it, expect, vi } from 'vitest'
+import { BetBoard } from '../components/BetBoard'
+import { numberGrid } from '../game/engine'
+
+describe('BetBoard', () => {
+  it('renders BetGrid and forwards cell clicks', () => {
+    const onCellClick = vi.fn()
+    const covered = new Set<number>()
+
+    render(
+      <BetBoard
+        grid={numberGrid}
+        mode="single"
+        onCellClick={onCellClick}
+        covered={covered}
+        winning={null}
+      />
+    )
+
+    const cell = screen.getByRole('gridcell', { name: '01' })
+    fireEvent.click(cell)
+    expect(onCellClick).toHaveBeenCalledWith(1)
+  })
+})

--- a/src/__tests__/basic.test.ts
+++ b/src/__tests__/basic.test.ts
@@ -1,7 +1,0 @@
-import { describe, it, expect } from 'vitest';
-
-describe('basic test', () => {
-  it('should work', () => {
-    expect(1 + 1).toBe(2);
-  });
-});

--- a/src/__tests__/utils.test.ts
+++ b/src/__tests__/utils.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest'
+import { clampInt, fmtUSD, fmtUSDSign } from '../utils'
+
+describe('utils', () => {
+  describe('clampInt', () => {
+    it('clamps values to range and floors', () => {
+      expect(clampInt(5.7, 0, 10)).toBe(5)
+      expect(clampInt(-2, 0, 10)).toBe(0)
+      expect(clampInt(20, 0, 10)).toBe(10)
+      expect(clampInt(Infinity, 0, 10)).toBe(0)
+    })
+  })
+
+  describe('fmtUSD', () => {
+    it('formats credits as USD', () => {
+      expect(fmtUSD(4)).toMatch(/\$1\.00/)
+    })
+  })
+
+  describe('fmtUSDSign', () => {
+    it('includes sign and formats', () => {
+      expect(fmtUSDSign(4)).toMatch(/^\+.*\$1\.00/)
+      expect(fmtUSDSign(-4)).toMatch(/^−.*\$1\.00/)
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- replace placeholder test with BetBoard component test
- add tests for clampInt and currency formatting utilities

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b2ffd02a5c83229ab9366e50ef961b