### PR TITLE
feat: link headers to home

### DIFF
--- a/src/Landing.tsx
+++ b/src/Landing.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, Link } from 'react-router-dom'
 import { HouseCert, validateHouseCert } from './certs/houseCert'
 import { syncWithAuthority } from './ledger/sync'
 import {
@@ -64,7 +64,9 @@ export default function Landing() {
     <div className="container">
       <header className="header">
         <div className="left" />
-        <h1>Roll-et</h1>
+        <h1>
+          <Link to="/">Roll-et</Link>
+        </h1>
         <div className="right" />
       </header>
 

--- a/src/components/HeaderBar.tsx
+++ b/src/components/HeaderBar.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { Link } from 'react-router-dom'
 import type { RoundState } from '../types'
 
 interface Props {
@@ -11,7 +12,9 @@ export function HeaderBar({ roundState }: Props) {
       <div className="left">
         <span className="seat">Seat: Open</span>
       </div>
-      <h1>Roll-et</h1>
+      <h1>
+        <Link to="/">Roll-et</Link>
+      </h1>
       <div className="right">
         <div className="credits">
           Round: <span className={`roundstate ${roundState}`}>{roundState.toUpperCase()}</span>

--- a/src/styles.css
+++ b/src/styles.css
@@ -29,6 +29,7 @@ body{
   margin-bottom: 8px;
 }
 .header h1{ margin: 0; font-size: 28px; text-align: center; }
+.header h1 a{ text-decoration: none; color: inherit; }
 .header .left{ justify-self: start; }
 .header .right{ justify-self: end; display:flex; gap:12px; align-items:center; }
 .link-btn{


### PR DESCRIPTION
## Summary
- wrap Roll-et title in HeaderBar and Landing with `Link` to homepage
- ensure header link inherits header style

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b302a0d64c8322b1444b6716c240a4