### PR TITLE
refactor: extract join logic and displays

### DIFF
--- a/src/Player.tsx
+++ b/src/Player.tsx
@@ -10,11 +10,9 @@ import BankReceiptScanner from './components/BankReceiptScanner'
 import type { BetCert } from './certs/betCert'
 import type { BankReceipt } from './certs/bankReceipt'
 import JoinScanner from './components/JoinScanner'
-import { houseCertRootPublicKeyJwk } from './certs/authorizedHouseCertLedger'
-import { validateHouseCert } from './certs/houseCert'
-import { joinResponseToQR } from './joinQR'
-import { pairingToQR } from './pairingQR'
-import { generateJoinTotp } from './utils/totp'
+import { useJoin } from './hooks/useJoin'
+import BetCertDisplay from './components/player/BetCertDisplay'
+import BankReceiptDisplay from './components/player/BankReceiptDisplay'
 
 function describeBet(b: Bet): string {
   switch (b.type) {
@@ -44,49 +42,21 @@ export default function Player() {
   const { canInstall, install, installed } = useInstallPrompt()
   const [scanningCert, setScanningCert] = React.useState(false)
   const [scanningReceipt, setScanningReceipt] = React.useState(false)
-  const [joining, setJoining] = React.useState(false)
   const [lastCert, setLastCert] = React.useState<BetCert | null>(null)
   const [lastReceipt, setLastReceipt] = React.useState<BankReceipt | null>(null)
-  const [joinQR, setJoinQR] = React.useState<string | null>(null)
-  const [playerKeys, setPlayerKeys] = React.useState<CryptoKeyPair | null>(null)
-  const [playerSecret, setPlayerSecret] = React.useState<CryptoKey | null>(null)
-  const [rootKey, setRootKey] = React.useState<CryptoKey | null>(null)
-  const [housePublicKey, setHousePublicKey] = React.useState<CryptoKey | null>(null)
-  const [pairQR, setPairQR] = React.useState<string | null>(null)
-  const [joinTotp, setJoinTotp] = React.useState<string | null>(null)
-  const [playerId, setPlayerId] = React.useState<string>(() => {
-    try {
-      return localStorage.getItem('roll_et_player_id') || 'Player'
-    } catch {
-      return 'Player'
-    }
-  })
-  React.useEffect(() => {
-    try { localStorage.setItem('roll_et_player_id', playerId) } catch {}
-  }, [playerId])
 
-  React.useEffect(() => {
-    ;(async () => {
-      // Player keys and secret for Join
-      const pkeys = await crypto.subtle.generateKey(
-        { name: 'ECDSA', namedCurve: 'P-256' },
-        true,
-        ['sign', 'verify']
-      )
-      const secret = await crypto.subtle.generateKey({ name: 'HMAC', hash: 'SHA-256' }, true, ['sign'])
-      setPlayerKeys(pkeys as CryptoKeyPair)
-      setPlayerSecret(secret)
-      // Root authority key (public) for validating HouseCerts in Join challenges
-      const rk = await crypto.subtle.importKey(
-        'jwk',
-        houseCertRootPublicKeyJwk,
-        { name: 'ECDSA', namedCurve: 'P-256' },
-        true,
-        ['verify']
-      )
-      setRootKey(rk)
-    })()
-  }, [])
+  const {
+    playerId,
+    setPlayerId,
+    joining,
+    setJoining,
+    joinQR,
+    joinTotp,
+    pairQR,
+    showPairingCode,
+    joinScannerProps,
+    housePublicKey,
+  } = useJoin()
 
   return (
     <div className="container">
@@ -104,7 +74,6 @@ export default function Player() {
             value={playerId}
             onChange={e => {
               const raw = e.target.value
-              // Allow A-Z, a-z, 0-9, dot, dash, underscore. No spaces. Max 16 chars.
               const sanitized = raw.replace(/[^A-Za-z0-9._-]/g, '').slice(0, 16)
               setPlayerId(sanitized)
             }}
@@ -140,35 +109,9 @@ export default function Player() {
         </section>
       )}
 
-      {joining && playerKeys && playerSecret && rootKey && (
+      {joining && joinScannerProps && (
         <section className="bets">
-          <JoinScanner
-            playerId={playerId || 'Player'}
-            playerKey={playerKeys.privateKey}
-            playerSecret={playerSecret}
-            rootKey={rootKey}
-            onResponse={async (resp) => {
-              const img = await joinResponseToQR(resp)
-              setJoinQR(img)
-              setJoining(false)
-            }}
-              onResponseEx={async (resp, challenge) => {
-                if (!playerSecret || !rootKey) return
-                const valid = await validateHouseCert(challenge.houseCert, rootKey)
-                if (!valid) return
-                const key = await crypto.subtle.importKey(
-                  'jwk',
-                  challenge.houseCert.payload.publicKeyJwk,
-                  { name: 'ECDSA', namedCurve: 'P-256' },
-                  true,
-                  ['verify']
-                )
-                setHousePublicKey(key)
-                const raw = await crypto.subtle.exportKey('raw', playerSecret)
-                const code = await generateJoinTotp(new Uint8Array(raw), resp.round, resp.nonce, challenge.nbf, 60_000)
-                setJoinTotp(code)
-              }}
-          />
+          <JoinScanner {...joinScannerProps} />
         </section>
       )}
 
@@ -181,12 +124,7 @@ export default function Player() {
       )}
 
       <section className="controls">
-        <button onClick={async () => {
-          if (!playerSecret) return
-          const raw = await crypto.subtle.exportKey('raw', playerSecret)
-          const qr = await pairingToQR(playerId || 'Player', new Uint8Array(raw))
-          setPairQR(qr)
-        }}>Show Pairing Code</button>
+        <button onClick={showPairingCode}>Show Pairing Code</button>
       </section>
 
       {pairQR && (
@@ -196,19 +134,9 @@ export default function Player() {
         </section>
       )}
 
-      {lastCert && (
-        <section className="bets">
-          <h3>Last Bet Cert</h3>
-          <pre>{JSON.stringify(lastCert, null, 2)}</pre>
-        </section>
-      )}
+      {lastCert && <BetCertDisplay cert={lastCert} />}
 
-      {lastReceipt && (
-        <section className="bets">
-          <h3>Last Bank Receipt</h3>
-          <pre>{JSON.stringify(lastReceipt, null, 2)}</pre>
-        </section>
-      )}
+      {lastReceipt && <BankReceiptDisplay receipt={lastReceipt} />}
 
       <section className="bets">
         {players.map(p => (
@@ -246,3 +174,4 @@ export default function Player() {
     </div>
   )
 }
+

--- a/src/components/player/BankReceiptDisplay.tsx
+++ b/src/components/player/BankReceiptDisplay.tsx
@@ -1,0 +1,14 @@
+import React from 'react'
+import type { BankReceipt } from '../../certs/bankReceipt'
+
+interface Props { receipt: BankReceipt }
+
+export default function BankReceiptDisplay({ receipt }: Props){
+  return (
+    <section className="bets">
+      <h3>Last Bank Receipt</h3>
+      <pre>{JSON.stringify(receipt, null, 2)}</pre>
+    </section>
+  )
+}
+

--- a/src/components/player/BetCertDisplay.tsx
+++ b/src/components/player/BetCertDisplay.tsx
@@ -1,0 +1,14 @@
+import React from 'react'
+import type { BetCert } from '../../certs/betCert'
+
+interface Props { cert: BetCert }
+
+export default function BetCertDisplay({ cert }: Props){
+  return (
+    <section className="bets">
+      <h3>Last Bet Cert</h3>
+      <pre>{JSON.stringify(cert, null, 2)}</pre>
+    </section>
+  )
+}
+

--- a/src/hooks/useJoin.ts
+++ b/src/hooks/useJoin.ts
@@ -1,0 +1,96 @@
+import React from 'react'
+import { joinResponseToQR } from '../joinQR'
+import { pairingToQR } from '../pairingQR'
+import { houseCertRootPublicKeyJwk } from '../certs/authorizedHouseCertLedger'
+import { validateHouseCert } from '../certs/houseCert'
+import { generateJoinTotp } from '../utils/totp'
+import type { JoinResponse, JoinChallenge } from '../join'
+
+export function useJoin(){
+  const [playerId, setPlayerId] = React.useState<string>(() => {
+    try { return localStorage.getItem('roll_et_player_id') || 'Player' } catch { return 'Player' }
+  })
+  React.useEffect(() => { try { localStorage.setItem('roll_et_player_id', playerId) } catch {} }, [playerId])
+
+  const [joining, setJoining] = React.useState(false)
+  const [joinQR, setJoinQR] = React.useState<string | null>(null)
+  const [joinTotp, setJoinTotp] = React.useState<string | null>(null)
+  const [pairQR, setPairQR] = React.useState<string | null>(null)
+  const [housePublicKey, setHousePublicKey] = React.useState<CryptoKey | null>(null)
+  const [playerKeys, setPlayerKeys] = React.useState<CryptoKeyPair | null>(null)
+  const [playerSecret, setPlayerSecret] = React.useState<CryptoKey | null>(null)
+  const [rootKey, setRootKey] = React.useState<CryptoKey | null>(null)
+
+  React.useEffect(() => {
+    ;(async () => {
+      const pkeys = await crypto.subtle.generateKey(
+        { name: 'ECDSA', namedCurve: 'P-256' },
+        true,
+        ['sign', 'verify']
+      )
+      const secret = await crypto.subtle.generateKey(
+        { name: 'HMAC', hash: 'SHA-256' },
+        true,
+        ['sign']
+      )
+      setPlayerKeys(pkeys as CryptoKeyPair)
+      setPlayerSecret(secret)
+      const rk = await crypto.subtle.importKey(
+        'jwk',
+        houseCertRootPublicKeyJwk,
+        { name: 'ECDSA', namedCurve: 'P-256' },
+        true,
+        ['verify']
+      )
+      setRootKey(rk)
+    })()
+  }, [])
+
+  const joinScannerProps = React.useMemo(() => {
+    if (!playerKeys || !playerSecret || !rootKey) return null
+    return {
+      playerId: playerId || 'Player',
+      playerKey: playerKeys.privateKey,
+      playerSecret,
+      rootKey,
+      onResponse: async (resp: JoinResponse) => {
+        const img = await joinResponseToQR(resp)
+        setJoinQR(img)
+        setJoining(false)
+      },
+      onResponseEx: async (resp: JoinResponse, challenge: JoinChallenge) => {
+        if (!playerSecret || !rootKey) return
+        const valid = await validateHouseCert(challenge.houseCert, rootKey)
+        if (!valid) return
+        const key = await crypto.subtle.importKey(
+          'jwk',
+          challenge.houseCert.payload.publicKeyJwk,
+          { name: 'ECDSA', namedCurve: 'P-256' },
+          true,
+          ['verify']
+        )
+        setHousePublicKey(key)
+        const raw = await crypto.subtle.exportKey('raw', playerSecret)
+        const code = await generateJoinTotp(new Uint8Array(raw), resp.round, resp.nonce, challenge.nbf, 60_000)
+        setJoinTotp(code)
+      }
+    }
+  }, [playerId, playerKeys, playerSecret, rootKey])
+
+  const showPairingCode = React.useCallback(async () => {
+    if (!playerSecret) return
+    const raw = await crypto.subtle.exportKey('raw', playerSecret)
+    const qr = await pairingToQR(playerId || 'Player', new Uint8Array(raw))
+    setPairQR(qr)
+  }, [playerSecret, playerId])
+
+  return {
+    playerId, setPlayerId,
+    joining, setJoining,
+    joinQR, joinTotp,
+    pairQR, showPairingCode,
+    joinScannerProps,
+    housePublicKey,
+  }
+}
+


### PR DESCRIPTION
## Summary
- move join state logic to reusable useJoin hook
- add BetCertDisplay and BankReceiptDisplay components for clarity
- streamline Player component with new hook and components

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: Cannot find package '@typescript-eslint/eslint-plugin')*


------
https://chatgpt.com/codex/tasks/task_e_68b3075b55088322a52f1605ec77a523