### PR TITLE
refactor: extract round settlement hook

### DIFF
--- a/src/__tests__/useRoundSettlement.test.ts
+++ b/src/__tests__/useRoundSettlement.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+vi.mock('../receipts', () => ({ issueReceiptsForWinners: vi.fn(async () => []) }))
+vi.mock('../ledger/localLedger', () => ({ appendLedger: vi.fn(async () => {}) }))
+
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { GameProvider, usePlayers, useStats, useHouse } from '../context/GameContext'
+import { useRoundSettlement } from '../hooks/useRoundSettlement'
+import type { Player } from '../types'
+import { issueReceiptsForWinners } from '../receipts'
+import { appendLedger as appendLedgerMock } from '../ledger/localLedger'
+
+const store: Record<string, string> = {}
+const localStorageMock = {
+  getItem(key: string) { return Object.prototype.hasOwnProperty.call(store, key) ? store[key] : null },
+  setItem(key: string, value: string) { store[key] = value },
+  removeItem(key: string) { delete store[key] },
+  clear() { for (const k in store) delete store[k] },
+}
+;(globalThis as any).localStorage = localStorageMock
+
+describe('useRoundSettlement', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    issueReceiptsForWinners.mockClear()
+    appendLedgerMock.mockClear()
+  })
+
+  it('settles a round and updates state', async () => {
+    const { result } = renderHook(() => {
+      const settlement = useRoundSettlement()
+      const { setPlayers, players } = usePlayers()
+      const { setBetCerts, houseKey } = useHouse()
+      const { stats } = useStats()
+      return { ...settlement, setPlayers, players, setBetCerts, houseKey, stats }
+    }, { wrapper: GameProvider })
+
+    await waitFor(() => expect(result.current.houseKey).not.toBeNull())
+
+    const players: Player[] = [
+      { id: 1, name: 'P1', bets: [{ id: 'b1', type: 'single', selection: [1], amount: 1 }], pool: 0, bank: 0 },
+      { id: 2, name: 'P2', bets: [], pool: 0, bank: 0 },
+    ]
+
+    act(() => { result.current.setPlayers(players) })
+    act(() => { result.current.setBetCerts({ 1: 'c1', 2: 'c2' }) })
+    act(() => { result.current.lockRound() })
+    act(() => { result.current.setEnteredRoll(1) })
+    await act(async () => { await result.current.settleRound() })
+
+    expect(result.current.players[0].bank).toBe(17)
+    expect(result.current.players[1].bank).toBe(0)
+    expect(result.current.stats.rounds).toBe(1)
+    expect(result.current.history.length).toBe(1)
+    expect(result.current.winning).toBe(1)
+    expect(appendLedgerMock).toHaveBeenCalledWith('round_settled', '1', expect.objectContaining({ roll: 1 }))
+    expect(issueReceiptsForWinners).toHaveBeenCalled()
+  })
+})
+

--- a/src/hooks/useBetting.ts
+++ b/src/hooks/useBetting.ts
@@ -1,19 +1,17 @@
 import React from 'react'
-import { Bet, makeCornerFromAnchor, resolveRound, getOdds } from '../game/engine'
-import { usePlayers, useRoundState, useStats, PER_ROUND_POOL, useHouse } from '../context/GameContext'
+import { Bet, makeCornerFromAnchor, getOdds } from '../game/engine'
+import { usePlayers, useRoundState, PER_ROUND_POOL } from '../context/GameContext'
 import type { BetMode, Player } from '../types'
 import { clampInt } from '../utils'
 import { useBetActions } from './useBetActions'
-import { issueReceiptsForWinners } from '../receipts'
-import { appendLedger } from '../ledger/localLedger'
+import { useRoundSettlement } from './useRoundSettlement'
 
 export const MIN_BET = 1
 
 export function useBetting() {
   const { players, setPlayers } = usePlayers()
-  const { roundState, setRoundState } = useRoundState()
-  const { stats, setStats } = useStats()
-  const { houseKey, betCerts, setBetCerts, setReceipts } = useHouse()
+  const { roundState } = useRoundState()
+  const { enteredRoll, setEnteredRoll, history, winning, lockRound, settleRound, newRound } = useRoundSettlement()
 
   const DEFAULT_BET = 1
   const [amount, setAmount] = React.useState<number>(() => {
@@ -24,9 +22,6 @@ export function useBetting() {
   React.useEffect(() => { localStorage.setItem('bet', String(amount)) }, [amount])
 
   const [mode, setMode] = React.useState<BetMode>({ kind: 'single' })
-  const [enteredRoll, setEnteredRoll] = React.useState<number | ''>('')
-  const [history, setHistory] = React.useState<Array<{ roll: number, deltas: Record<number, number>, time: number }>>([])
-  const [winning, setWinning] = React.useState<number | null>(null)
 
   const [activeId, setActiveId] = React.useState<number | null>(players[0]?.id ?? null)
   React.useEffect(() => {
@@ -115,65 +110,6 @@ export function useBetting() {
     }
   }
 
-  const lockRound = () => { setRoundState('locked') }
-
-  const settleRound = async () => {
-    if (roundState !== 'locked') return
-    const roll = Number(enteredRoll)
-    if (!Number.isInteger(roll) || roll < 1 || roll > 20) return
-
-    const deltas: Record<number, number> = {}
-    const nextPlayers = players.map(p => {
-      const stake = p.bets.reduce((a, b) => a + b.amount, 0)
-      const win = resolveRound(roll, p.bets)
-      const delta = win - stake
-      deltas[p.id] = delta
-      return { ...p, bank: p.bank + delta }
-    })
-
-    setStats(prev => {
-      const hits = [...prev.hits]
-      hits[roll] = (hits[roll] || 0) + 1
-      const banks = { ...prev.banks }
-      nextPlayers.forEach(p => { banks[p.id] = p.bank })
-      return { rounds: prev.rounds + 1, hits, banks }
-    })
-
-    if (houseKey) {
-      const winners = players
-        .filter(p => deltas[p.id] > 0)
-        .map(p => ({ player: p.id, value: deltas[p.id], betCertRef: betCerts[p.id] || '' }))
-      const roundId = String(stats.rounds + 1)
-      const recs = await issueReceiptsForWinners(winners, roundId, houseKey.privateKey)
-      setReceipts(recs)
-      for (let i = 0; i < winners.length; i++) {
-        const w = winners[i]
-        const rec = (recs[i] && recs[i].receipt) ? recs[i] : undefined
-        await appendLedger('receipt_issued', roundId, {
-          player: String(w.player),
-          value: w.value,
-          betCertRef: w.betCertRef,
-          receiptId: rec?.receipt.receiptId,
-          spendCode: rec?.spendCode,
-        })
-      }
-    }
-
-    setPlayers(nextPlayers)
-    await appendLedger('round_settled', String(stats.rounds + 1), { roll, deltas })
-    setHistory(h => [{ roll, deltas, time: Date.now() }, ...h].slice(0, 30))
-    setWinning(roll)
-    setRoundState('settled')
-  }
-
-  const newRound = () => {
-    setPlayers(prev => prev.map(p => ({ ...p, pool: PER_ROUND_POOL, bets: [] })))
-    setEnteredRoll('')
-    setWinning(null)
-    setRoundState('open')
-    setBetCerts({})
-    setReceipts([])
-  }
 
   const describeBet = (b: Bet) => {
     switch (b.type) {

--- a/src/hooks/useRoundSettlement.ts
+++ b/src/hooks/useRoundSettlement.ts
@@ -1,0 +1,87 @@
+import React from 'react'
+import { resolveRound } from '../game/engine'
+import { usePlayers, useRoundState, useStats, PER_ROUND_POOL, useHouse } from '../context/GameContext'
+import { issueReceiptsForWinners } from '../receipts'
+import { appendLedger } from '../ledger/localLedger'
+
+export function useRoundSettlement() {
+  const { players, setPlayers } = usePlayers()
+  const { roundState, setRoundState } = useRoundState()
+  const { stats, setStats } = useStats()
+  const { houseKey, betCerts, setBetCerts, setReceipts } = useHouse()
+
+  const [enteredRoll, setEnteredRoll] = React.useState<number | ''>('')
+  const [history, setHistory] = React.useState<Array<{ roll: number, deltas: Record<number, number>, time: number }>>([])
+  const [winning, setWinning] = React.useState<number | null>(null)
+
+  const lockRound = () => { setRoundState('locked') }
+
+  const settleRound = async () => {
+    if (roundState !== 'locked') return
+    const roll = Number(enteredRoll)
+    if (!Number.isInteger(roll) || roll < 1 || roll > 20) return
+
+    const deltas: Record<number, number> = {}
+    const nextPlayers = players.map(p => {
+      const stake = p.bets.reduce((a, b) => a + b.amount, 0)
+      const win = resolveRound(roll, p.bets)
+      const delta = win - stake
+      deltas[p.id] = delta
+      return { ...p, bank: p.bank + delta }
+    })
+
+    setStats(prev => {
+      const hits = [...prev.hits]
+      hits[roll] = (hits[roll] || 0) + 1
+      const banks = { ...prev.banks }
+      nextPlayers.forEach(p => { banks[p.id] = p.bank })
+      return { rounds: prev.rounds + 1, hits, banks }
+    })
+
+    if (houseKey) {
+      const winners = players
+        .filter(p => deltas[p.id] > 0)
+        .map(p => ({ player: p.id, value: deltas[p.id], betCertRef: betCerts[p.id] || '' }))
+      const roundId = String(stats.rounds + 1)
+      const recs = await issueReceiptsForWinners(winners, roundId, houseKey.privateKey)
+      setReceipts(recs)
+      for (let i = 0; i < winners.length; i++) {
+        const w = winners[i]
+        const rec = (recs[i] && recs[i].receipt) ? recs[i] : undefined
+        await appendLedger('receipt_issued', roundId, {
+          player: String(w.player),
+          value: w.value,
+          betCertRef: w.betCertRef,
+          receiptId: rec?.receipt.receiptId,
+          spendCode: rec?.spendCode,
+        })
+      }
+    }
+
+    setPlayers(nextPlayers)
+    await appendLedger('round_settled', String(stats.rounds + 1), { roll, deltas })
+    setHistory(h => [{ roll, deltas, time: Date.now() }, ...h].slice(0, 30))
+    setWinning(roll)
+    setRoundState('settled')
+  }
+
+  const newRound = () => {
+    setPlayers(prev => prev.map(p => ({ ...p, pool: PER_ROUND_POOL, bets: [] })))
+    setEnteredRoll('')
+    setWinning(null)
+    setRoundState('open')
+    setBetCerts({})
+    setReceipts([])
+  }
+
+  return {
+    enteredRoll,
+    setEnteredRoll,
+    history,
+    winning,
+    lockRound,
+    settleRound,
+    newRound,
+  }
+}
+


### PR DESCRIPTION
## Summary
- move round settlement, receipt issuance and ledger writes to a dedicated `useRoundSettlement` hook
- keep `useBetting` focused on bet placement and state by consuming the new hook
- cover round settlement behavior with a new unit test

## Testing
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68b30a2be8d08322b3b7bad097e455e2