### PR TITLE
Add round settlement hook and tests

### DIFF
--- a/src/__tests__/useRoundSettlement.test.ts
+++ b/src/__tests__/useRoundSettlement.test.ts
@@ -1,0 +1,43 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from "vitest"
+import { renderHook, act } from '@testing-library/react'
+import { GameProvider } from '../context/GameContext'
+import { useRoundSettlement } from '../hooks/useRoundSettlement'
+import { usePlayers, useRoundState, useStats } from '../context/GameContext'
+import type { Player } from '../types'
+
+describe('useRoundSettlement', () => {
+  it('settles a round updating banks and stats', async () => {
+    const { result } = renderHook(() => {
+      const { settleRound } = useRoundSettlement()
+      const playersCtx = usePlayers()
+      const roundCtx = useRoundState()
+      const statsCtx = useStats()
+      return { settleRound, ...playersCtx, ...roundCtx, ...statsCtx }
+    }, { wrapper: GameProvider })
+
+    const players: Player[] = [
+      { id: 1, name: 'P1', bets: [{ id: 'b1', type: 'single', selection: [7], amount: 2 }], pool: 0, bank: 0 },
+      { id: 2, name: 'P2', bets: [{ id: 'b2', type: 'even', selection: [], amount: 1 }], pool: 0, bank: 0 }
+    ]
+
+    act(() => {
+      result.current.setPlayers(players)
+      result.current.setStats({ rounds: 0, hits: Array(21).fill(0), banks: {} })
+      result.current.setRoundState('locked')
+    })
+
+    await act(async () => {
+      await result.current.settleRound(7)
+    })
+
+    expect(result.current.players[0].bank).toBe(34)
+    expect(result.current.players[1].bank).toBe(-1)
+    expect(result.current.roundState).toBe('settled')
+    expect(result.current.stats.rounds).toBe(1)
+    expect(result.current.stats.hits[7]).toBe(1)
+    expect(result.current.stats.banks[1]).toBe(34)
+    expect(result.current.stats.banks[2]).toBe(-1)
+  })
+})
+

--- a/src/hooks/useRoundSettlement.ts
+++ b/src/hooks/useRoundSettlement.ts
@@ -1,0 +1,46 @@
+import React from 'react'
+import { resolveRound } from '../game/engine'
+import { usePlayers, useRoundState, useStats, useHouse } from '../context/GameContext'
+
+/**
+ * Hook to settle a round given the winning roll.
+ * It updates player banks, stats, and round state.
+ */
+export function useRoundSettlement() {
+  const { players, setPlayers } = usePlayers()
+  const { roundState, setRoundState } = useRoundState()
+  const { stats, setStats } = useStats()
+  const { setReceipts, setBetCerts } = useHouse() // to reset after settlement
+
+  const settleRound = React.useCallback(async (roll: number) => {
+    if (roundState !== 'locked') return
+    if (!Number.isInteger(roll) || roll < 1 || roll > 20) return
+
+    const deltas: Record<number, number> = {}
+    const nextPlayers = players.map(p => {
+      const stake = p.bets.reduce((a, b) => a + b.amount, 0)
+      const win = resolveRound(roll, p.bets)
+      const delta = win - stake
+      deltas[p.id] = delta
+      return { ...p, bank: p.bank + delta }
+    })
+
+    setPlayers(nextPlayers)
+    setStats(prev => {
+      const hits = [...prev.hits]
+      hits[roll] = (hits[roll] || 0) + 1
+      const banks = { ...prev.banks }
+      nextPlayers.forEach(p => { banks[p.id] = p.bank })
+      return { rounds: prev.rounds + 1, hits, banks }
+    })
+
+    // clear bet certs and receipts for new round context
+    setBetCerts({})
+    setReceipts([])
+    setRoundState('settled')
+    return deltas
+  }, [players, roundState, setPlayers, setRoundState, setStats, setReceipts, setBetCerts])
+
+  return { settleRound }
+}
+


### PR DESCRIPTION
## Summary
- implement `useRoundSettlement` hook to settle a round and update banks, stats, and receipts
- add `useRoundSettlement.test.ts` with jsdom environment to verify settlement logic

## Testing
- `npm run test:node`


------
https://chatgpt.com/codex/tasks/task_e_68b314f461188322919a8ec366a0b96f