### PR TITLE
Refine BetBoard mode handling with type narrowing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -90,9 +90,9 @@ export default function App() {
 
       <BetBoard
         grid={numberGrid}
-        mode={(mode as any).kind}
+        mode={mode.kind}
         onCellClick={onCellClick}
-        splitFirst={(mode as any).kind === 'split' ? (mode as any).first : undefined}
+        splitFirst={mode.kind === 'split' && mode.first}
         covered={covered}
         winning={winning}
       />

--- a/src/components/BetBoard.tsx
+++ b/src/components/BetBoard.tsx
@@ -6,7 +6,7 @@ interface Props {
   grid: number[][]
   mode: BetMode['kind']
   onCellClick: (n: number) => void
-  splitFirst?: number
+  splitFirst?: number | false
   covered: Set<number>
   winning: number | null
 }

--- a/src/components/BetGrid.tsx
+++ b/src/components/BetGrid.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 interface Props {
   grid: number[][]
   mode: string
-  splitFirst?: number
+  splitFirst?: number | false
   onCellClick: (n: number) => void
   covered: Set<number>
   winning?: number | null


### PR DESCRIPTION
## Summary
- access bet mode directly via `mode.kind`
- use TypeScript narrowing for `splitFirst`
- allow `false` in BetBoard/BetGrid `splitFirst` prop

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b317d9fee48322a95603a44edc0892