### PR TITLE
refactor: centralize bet helpers

### DIFF
--- a/src/Player.tsx
+++ b/src/Player.tsx
@@ -2,8 +2,7 @@ import React from 'react'
 import { Link } from 'react-router-dom'
 import { usePlayers } from './context/GameContext'
 import { fmtUSD, fmtUSDSign } from './utils'
-import { getOdds } from './game/engine'
-import type { Bet } from './game/engine'
+import { describeBet, potential } from './utils/betHelpers'
 import { useInstallPrompt } from './pwa/useInstallPrompt'
 import BetCertScanner from './components/BetCertScanner'
 import BankReceiptScanner from './components/BankReceiptScanner'
@@ -13,29 +12,6 @@ import JoinScanner from './components/JoinScanner'
 import { useJoin } from './hooks/useJoin'
 import BetCertDisplay from './components/player/BetCertDisplay'
 import BankReceiptDisplay from './components/player/BankReceiptDisplay'
-
-function describeBet(b: Bet): string {
-  switch (b.type) {
-    case 'single':
-      return `#${b.selection[0]}`
-    case 'split':
-      return `Split ${b.selection.join(' / ')}`
-    case 'corner':
-      return `Corner ${b.selection.join('-')}`
-    case 'even':
-      return 'Even'
-    case 'odd':
-      return 'Odd'
-    case 'high':
-      return 'High 11–20'
-    case 'low':
-      return 'Low 1–10'
-  }
-}
-
-function potential(b: Bet): number {
-  return b.amount * getOdds(b.type)
-}
 
 export default function Player() {
   const { players } = usePlayers()

--- a/src/__tests__/betHelpers.test.ts
+++ b/src/__tests__/betHelpers.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest'
+import { describeBet, potential } from '../utils/betHelpers'
+import { getOdds, type Bet } from '../game/engine'
+
+describe('betHelpers', () => {
+  it('describes different bet types', () => {
+    const single: Bet = { id: '1', type: 'single', selection: [5], amount: 1 }
+    const split: Bet = { id: '2', type: 'split', selection: [3, 4], amount: 1 }
+    const corner: Bet = { id: '3', type: 'corner', selection: [6, 7, 11, 12], amount: 1 }
+    const even: Bet = { id: '4', type: 'even', selection: [], amount: 1 }
+
+    expect(describeBet(single)).toBe('#5')
+    expect(describeBet(split)).toBe('Split 3 / 4')
+    expect(describeBet(corner)).toBe('Corner 6-7-11-12')
+    expect(describeBet(even)).toBe('Even')
+  })
+
+  it('calculates potential payout', () => {
+    const bet: Bet = { id: '5', type: 'split', selection: [1, 2], amount: 3 }
+    expect(potential(bet)).toBe(3 * getOdds('split'))
+  })
+})

--- a/src/hooks/useBetting.ts
+++ b/src/hooks/useBetting.ts
@@ -1,5 +1,6 @@
 import React from 'react'
-import { Bet, makeCornerFromAnchor, resolveRound, getOdds } from '../game/engine'
+import { Bet, makeCornerFromAnchor, resolveRound } from '../game/engine'
+import { describeBet, potential } from '../utils/betHelpers'
 import { usePlayers, useRoundState, useStats, PER_ROUND_POOL, useHouse } from '../context/GameContext'
 import type { BetMode, Player } from '../types'
 import { clampInt } from '../utils'
@@ -174,20 +175,6 @@ export function useBetting() {
     setBetCerts({})
     setReceipts([])
   }
-
-  const describeBet = (b: Bet) => {
-    switch (b.type) {
-      case 'single': return `#${b.selection[0]}`
-      case 'split': return `Split ${b.selection.join(' / ')}`
-      case 'corner': return `Corner ${b.selection.join('-')}`
-      case 'even': return 'Even'
-      case 'odd': return 'Odd'
-      case 'high': return 'High 11–20'
-      case 'low': return 'Low 1–10'
-    }
-  }
-
-  const potential = (b: Bet) => b.amount * getOdds(b.type)
 
   return {
     players,

--- a/src/utils/betHelpers.ts
+++ b/src/utils/betHelpers.ts
@@ -1,0 +1,26 @@
+import { getOdds } from '../game/engine'
+import type { Bet } from '../game/engine'
+
+export function describeBet(b: Bet): string {
+  switch (b.type) {
+    case 'single':
+      return `#${b.selection[0]}`
+    case 'split':
+      return `Split ${b.selection.join(' / ')}`
+    case 'corner':
+      return `Corner ${b.selection.join('-')}`
+    case 'even':
+      return 'Even'
+    case 'odd':
+      return 'Odd'
+    case 'high':
+      return 'High 11–20'
+    case 'low':
+      return 'Low 1–10'
+  }
+}
+
+export function potential(b: Bet): number {
+  return b.amount * getOdds(b.type)
+}
+


### PR DESCRIPTION
## Summary
- centralize bet description and potential payout helpers
- reuse shared helpers in `useBetting` hook and `Player` component
- add unit tests for bet helper functions

## Testing
- `npx vitest run --environment jsdom`


------
https://chatgpt.com/codex/tasks/task_e_68b32af817208322b8044f1e6c6a74c6