### PR TITLE
chore: broaden node test glob

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "tsc -b && vite build",
     "preview": "vite preview --port 5173",
     "test": "vitest --environment jsdom",
-    "test:node": "vitest run --environment node src/__tests__/*.test.ts",
+    "test:node": "bash -lc 'shopt -s globstar; vitest run --environment node src/__tests__/**/*.test.{ts,tsx}'",
     "docs:flow": "mmdc -p docs/puppeteer.config.json -i docs/flowchart.mmd -o docs/flowchart.svg",
     "docs:flow:png": "mmdc -p docs/puppeteer.config.json -i docs/flowchart.mmd -o docs/flowchart.png",
     "lint": "eslint . --ext .ts,.tsx --config .eslintrc",

--- a/src/__tests__/BankReceiptScanner.test.tsx
+++ b/src/__tests__/BankReceiptScanner.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { describe, it, expect, vi } from 'vitest'
 import { render, waitFor } from '@testing-library/react'
 import React from 'react'

--- a/src/__tests__/BetBoard.test.tsx
+++ b/src/__tests__/BetBoard.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { render, screen, fireEvent } from '@testing-library/react'
 import '@testing-library/jest-dom/vitest'
 import { describe, it, expect, vi } from 'vitest'

--- a/src/__tests__/BetCertScanner.test.tsx
+++ b/src/__tests__/BetCertScanner.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { describe, it, expect, vi } from 'vitest'
 import { render, waitFor } from '@testing-library/react'
 import React from 'react'

--- a/src/__tests__/BetGrid.test.tsx
+++ b/src/__tests__/BetGrid.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
 import { describe, it, expect, vi } from 'vitest';

--- a/src/__tests__/JoinScannerFallback.test.tsx
+++ b/src/__tests__/JoinScannerFallback.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { describe, it, expect, vi } from 'vitest'
 import { render, waitFor } from '@testing-library/react'
 import React from 'react'

--- a/src/__tests__/Stats.test.tsx
+++ b/src/__tests__/Stats.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
 import { describe, it, expect, vi } from 'vitest';


### PR DESCRIPTION
## Summary
- broaden `test:node` glob to include `.test.ts` and `.test.tsx`
- mark DOM-based tests with `@vitest-environment jsdom`

## Testing
- `npm run test:node`


------
https://chatgpt.com/codex/tasks/task_e_68b3312a30f08322a871c7c9f68a3752