### PR TITLE
Fix PWA navigation fallback to allow SPA routes

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,8 +14,23 @@ export default defineConfig({
          cleanupOutdatedCaches: true,
          clientsClaim: true,
          skipWaiting: true,
-         navigateFallback: '/roll-et/offline.html',
+         navigateFallback: '/roll-et/index.html',
          runtimeCaching: [
+           {
+             urlPattern: ({ request }) => request.mode === 'navigate',
+             handler: 'NetworkFirst',
+             options: {
+               cacheName: 'page-cache',
+               networkTimeoutSeconds: 10,
+               plugins: [
+                 {
+                   handlerDidError: async () => {
+                     return caches.match('/roll-et/offline.html');
+                   },
+                 },
+               ],
+            },
+          },
            {
              urlPattern: ({ url }) => url.pathname.startsWith('/api'),
              method: 'GET',


### PR DESCRIPTION
## Summary
- serve index.html for SPA routes instead of offline page
- add navigation cache with offline fallback to offline.html when network fails

## Testing
- `npm test -- --run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b43c38c2f883229a9b44d9b6c35717