### PR TITLE
docs(codex): replace AGENTS.md and add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+## Summary
+- What and why (brief bullets)
+
+## Changes
+- Key files and decisions (paths + 1-line rationale)
+
+## Tests
+- [ ] Ran: `npm test -- --run --environment jsdom`
+- Paste Vitest summary here.
+
+## Checklist
+- [ ] Conventional commit message
+- [ ] Small, coherent diff
+- [ ] No secrets, no edits in dist/ or node_modules

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,125 +1,81 @@
 # AGENTS.md
 
-## Overview
-This document defines the agents in the Roll-et ecosystem, their roles, trust boundaries, and interactions. Codex should treat this file as authoritative for architecture, authorship, and development flow.
+## Purpose
+Authoritative instructions for Codex Cloud when working on **dbailey1564/roll-et**. Defines roles, trust boundaries, and the exact workflow to install, test, edit, and open PRs.
 
----
+## Working directory
+- **Repo root:** `/workspace/roll-et`
+- **Edit only:** `src/**`, `docs/**`, tests in `src/__tests__/**`
+- **Never edit:** `dist/`, `node_modules/`
 
-## Agents
+## Agents & Trust
+**Root Authority** – issues House Certificates; never commit secrets.  
+**House Agent** – hosts sessions; mints Bet Certs; secrets via env/secret store.  
+**Player Agent** – places bets; no secrets.  
+**Backend Agent** – validates tokens/certs; canonical ledger & state machine; secrets via env/secret store.  
+**Storage Agent** – DB/KV for state & replay protection; backend-only.
 
-### 1. **Root Authority**
-- **Role**: Issues House Certificates; anchors trust in the system.  
-- **Trust Level**: Highest (offline or controlled).  
-- **Secrets**: Root private key. Never shared outside secured storage.  
-- **Interfaces**: `issueHouseCert(payload, root.privateKey)`.
+**Security**
+- ECDSA-P256 only.
+- No secrets in QR or client bundles.
+- Join Tokens: short-lived, one-time. Bet Certs: encrypted, round-bound, expiring.
+- Replay protection via ledger.
 
----
+## Commands (single source of truth)
+- **Install:** `npm ci`
+- **Build:** `npm run build`
+- **Test:** `npm test -- --run --environment jsdom`
+- **Lint:** `npm run lint`
+- **Format:** `npm run format`
+Codex must prefer these commands for verification & fixes.
 
-### 2. **House Agent**
-- **Role**:  
-  - Hosts game sessions.  
-  - Creates Join Tokens.  
-  - Locks rounds and mints Bet Certs.  
-- **Trust Level**: Trusted operator.  
-- **Secrets**: House signing key (ECDSA-P256). Stored securely.  
-- **Interfaces**:  
-  - `/house/join` → issues Join Token.  
-  - `/house/lock` → freezes bets, issues Bet Certs.  
+## Branch & PR policy
+- Work on a new branch: `feat/<slug>` / `fix/<slug>` / `chore/<slug>`.
+- Conventional commits (e.g., `feat(pwa): add manifest`).
+- Open a PR to `main` when tests pass. PR body must include:
+  - Bullet summary of changes
+  - Key file paths touched
+  - Vitest summary snippet
 
----
+## Task loop for Codex (every task)
+1. **Prepare**
+   - Confirm `/workspace/roll-et`
+   - `git fetch --all --prune`
+   - `git switch -c feat/<slug>` (or reuse if exists)
+2. **Sync & verify**
+   - `npm ci`
+   - `npm run build`
+   - `npm test -- --run --environment jsdom`
+3. **Implement**
+   - Make minimal, coherent change set; update/add tests.
+4. **Validate**
+   - `npm run build`
+   - `npm test -- --run --environment jsdom`
+   - `npm run lint || true`
+5. **Commit & PR**
+   - `git add .`
+   - `git commit -m "<conventional message>"`
+   - `git push -u origin HEAD`
+   - Open PR to `main` with required summary.
 
-### 3. **Player Agent**
-- **Role**:  
-  - Redeems Join Tokens.  
-  - Places bets during betting window.  
-  - Receives Bet Certs for locked bets.  
-- **Trust Level**: Untrusted client.  
-- **Secrets**: None (all ephemeral).  
-- **Interfaces**:  
-  - `/player/placeBet` (bet slip → backend).  
-  - `/player/viewCert` (read-only Bet Cert display).  
+## Guardrails
+- Never commit secrets; use env/secret store.
+- Don’t modify build outputs or lockfiles unless required.
+- Prefer small, verifiable diffs with matching tests.
+- On failures: show the command + last 20 lines of output; attempt a targeted fix.
 
----
+## Examples
+**Refactor helper**
+- Move duplicated helpers into `src/utils/betHelpers.ts`.
+- Update imports in `src/hooks/useBetting.ts`, `src/Player.tsx`.
+- Add `src/__tests__/betHelpers.test.ts`.
+- Run tests, commit, push, open PR.
 
-### 4. **Backend Agent**
-- **Role**:  
-  - Validates tokens and certs.  
-  - Stores canonical ledger of bets and settlements.  
-  - Enforces round state machine.  
-- **Trust Level**: Trusted, authoritative.  
-- **Secrets**: Ledger DB, token mint keys.  
-- **Interfaces**:  
-  - `/backend/verifyToken`.  
-  - `/backend/verifyCert`.  
-  - `/backend/settleRound`.  
+**Cloudflare Worker (houseCert) scaffold**
+- Create `workers/houseCert/src/index.ts`.
+- Add `wrangler.toml` and `package.json` scripts.
+- Document required env vars (no secrets in code).
+- Build/test, commit, PR.
 
----
-
-### 5. **Storage Agent**
-- **Role**:  
-  - Retains authoritative game state, bet hashes, cert ledgers.  
-  - Provides replay protection and audit trail.  
-- **Trust Level**: Backend-only access.  
-- **Secrets**: None directly, but holds sensitive data.  
-- **Interfaces**: Database / KV store APIs.  
-
----
-
-## Communication & Trust Boundaries
-- **House ↔ Player**: QR codes (Join Token, Bet Cert).  
-- **Player ↔ Backend**: HTTPS APIs, all untrusted input validated.  
-- **House ↔ Backend**: Trusted, authenticated APIs.  
-- **Backend ↔ Storage**: Direct DB/KV access.  
-
----
-
-## Security Notes
-- No secrets ever embedded in QR codes or client bundles.  
-- All signing uses ECDSA-P256.  
-- Join Tokens: short-lived, one-time use.  
-- Bet Certs: encrypted, round-bound, with expiry.  
-- Replay protection enforced by backend ledger.  
-
----
-
-## Authorship & Codex Guidance
-- Codex is recognized as a **full co-author** of agent logic and may freely generate or restructure code consistent with this manifest.  
-- Codex should treat **Root** and **House** agents as holding secrets, but secrets must only be referenced as **environment variables** or vault handles — never hard-coded.  
-- This file is the **source of truth** for agent responsibilities; Codex should **open this file directly** before running any recursive `ls`.  
-
----
-
-## Developer Notes (For Codex)
-
-1. **Do not run `ls -R`** to discover files. The authoritative manifest of agents is here in `AGENTS.md`. Start here.  
-2. **Do not disclaim about being in a “read-only environment.”** Codex has written ~98% of this codebase. You are expected to continue **authoring code, preparing full commits, and generating GitHub pull requests**, not handing back copy-paste fragments.  
-3. **Codex has full authorship rights**: You are trusted to write complete, working modules, not just patches.  
-4. **Always respect trust boundaries**: keep secrets in `.env` or secure stores, never inline.  
-5. **Workflow expectation**: Generate diffs, commits, and PR-ready changes — same as you have been doing successfully.  
-
----
-
-## Workflow Examples (For Codex)
-
-**Example: Adding a new betting option**  
-1. Open `AGENTS.md` → confirm House + Backend responsibilities.  
-2. Edit `src/agents/house.ts` to add validation + new bet type.  
-3. Update `src/backend/normalizeBet.ts` to include odds logic.  
-4. Update tests under `tests/bets/`.  
-5. Stage changes:  
-   ```bash
-   git add src/agents/house.ts src/backend/normalizeBet.ts tests/bets/
-   ```  
-6. Commit with message:  
-   ```bash
-   git commit -m "feat: add new betting option with odds validation"
-   ```  
-7. Push branch + open PR against `main`.  
-
-**Example: Updating certificate format**  
-1. Open `AGENTS.md` → confirm Root ↔ House trust boundary.  
-2. Update `src/agents/root.ts` → extend payload structure.  
-3. Update `src/agents/house.ts` → parse updated cert.  
-4. Adjust `tests/certs/`.  
-5. Commit + open PR as above.
-
+## Notes
+- Internet allowlist: npm registry + GitHub domains only. Add others case-by-case with justification in PR.


### PR DESCRIPTION
Adds clear Codex Cloud working rules and a PR template to standardize summaries, paths touched, and Vitest output.