### PR TITLE
docs: unify test command to 'npm test -- --run'

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,7 +5,7 @@
 - Key files and decisions (paths + 1-line rationale)
 
 ## Tests
-- [ ] Ran: `npm test -- --run --environment jsdom`
+- [ ] Ran: `npm test -- --run`
 - Paste Vitest summary here.
 
 ## Checklist

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ Authoritative instructions for Codex Cloud when working on **dbailey1564/roll-et
 ## Commands (single source of truth)
 - **Install:** `npm ci`
 - **Build:** `npm run build`
-- **Test:** `npm test -- --run --environment jsdom`
+- **Test:** `npm test -- --run`
 - **Lint:** `npm run lint`
 - **Format:** `npm run format`
 Codex must prefer these commands for verification & fixes.
@@ -45,12 +45,12 @@ Codex must prefer these commands for verification & fixes.
 2. **Sync & verify**
    - `npm ci`
    - `npm run build`
-   - `npm test -- --run --environment jsdom`
+   - `npm test -- --run`
 3. **Implement**
    - Make minimal, coherent change set; update/add tests.
 4. **Validate**
    - `npm run build`
-   - `npm test -- --run --environment jsdom`
+   - `npm test -- --run`
    - `npm run lint || true`
 5. **Commit & PR**
    - `git add .`


### PR DESCRIPTION
Centralizes jsdom in package.json's test script and removes duplicate '--environment' flag from docs/templates. Prevents Vitest error when both the script and command line pass '--environment'. No code changes.