### PR TITLE
chore(gitignore): ignore secret directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@ pnpm-debug.log*
 .env
 .env.*.local
 
+# Secret storage
+.sec/
+
 # TypeScript cache
 *.tsbuildinfo
 

--- a/setup-sec.sh
+++ b/setup-sec.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Create a local directory for secret key material
+mkdir -p .sec
+
+cat <<'MSG'
+Initialized .sec directory for secret keys.
+This folder is gitignored; place your private key and JWK files here.
+MSG


### PR DESCRIPTION
## Summary
- ignore local `.sec` directory for secrets
- add helper script to scaffold the `.sec` directory

## Testing
- `npm run build`
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b8b7459e4c83228e7fff9262f3d48d