### PR TITLE
fix(docs): clarify GitHub Pages deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ npm run preview
 ## Deploy to GitHub Pages
 1. Create repo `roll-et` under `dbailey1564`.
 2. Push code.
-3. In the repo settings → Pages, set: Build and deployment = GitHub Actions.
-4. The included workflow publishes `/dist` to `gh-pages` branch.
+3. In the repo settings → Pages, enable GitHub Pages by setting **Build and deployment** to **GitHub Actions**. The deploy step will fail with a 404 if Pages isn't enabled.
+4. The included workflow builds `dist/` and publishes it using [`actions/deploy-pages`](https://github.com/actions/deploy-pages).
 5. Site URL: https://dbailey1564.github.io/roll-et/
 
 ## Documentation


### PR DESCRIPTION
## Summary
- document that GitHub Pages must be enabled before running the deploy workflow
- note that deploy uses `actions/deploy-pages` instead of pushing to `gh-pages`

## Testing
- `npm run build`
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b98427c5348322bb7c464bbb53f5f1