### PR TITLE
chore(ci): split jobs to isolate failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  ci:
-    name: build • test • diagrams
+  build:
+    name: Build
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -34,11 +34,32 @@ jobs:
       - name: Install (lockfile)
         run: npm ci
 
-      - name: Test
-        run: npm test -- --run
-
       - name: Build
         run: npm run build
+
+  diagrams:
+    name: Generate diagrams
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: read
+    env:
+      CI: true
+      ROLLUP_SKIP_NODEJS_NATIVE: '1'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install (lockfile)
+        run: npm ci
 
       - name: Generate Mermaid SVG (soft-skip if missing)
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 jobs:
-  test:
+  jsdom:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -24,6 +24,21 @@ jobs:
 
       - name: Run jsdom tests
         run: npm test
+
+  node:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
 
       - name: Run node tests
         run: npm run test:node


### PR DESCRIPTION
## Summary
- split build and diagram generation into separate CI jobs
- run jsdom and node tests in distinct jobs

## Testing
- `npm run build`
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b98c34de308322a54ff79a24ebe304