### PR TITLE
chore(setup-sec): capture ROOT_PUBLIC_JWK

### DIFF
--- a/setup-sec.sh
+++ b/setup-sec.sh
@@ -4,6 +4,16 @@ set -euo pipefail
 # Create a local directory for secret key material
 mkdir -p .sec
 
+if [[ -z "${ROOT_PUBLIC_JWK:-}" ]]; then
+  echo "ROOT_PUBLIC_JWK not set" >&2
+  exit 1
+fi
+printf '%s' "$ROOT_PUBLIC_JWK" > .sec/root_public_jwk.json
+
+if [[ -n "${ROOT_PRIVATE_KEY:-}" ]]; then
+  printf '%s' "$ROOT_PRIVATE_KEY" > .sec/root_private_key.pem
+fi
+
 cat <<'MSG'
 Initialized .sec directory for secret keys.
 This folder is gitignored; place your private key and JWK files here.


### PR DESCRIPTION
## Summary
- require `ROOT_PUBLIC_JWK` to run setup script and save to `.sec/root_public_jwk.json`
- optionally persist `ROOT_PRIVATE_KEY` in `.sec/root_private_key.pem`

## Testing
- `npm run build`
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b996e19a588322abbea00a5b1f00fe