### PR TITLE
docs(join): revise join response contract

### DIFF
--- a/docs/join_challenge_response_contract.md
+++ b/docs/join_challenge_response_contract.md
@@ -7,14 +7,14 @@ Provide a secure, offline-verifiable admission mechanism for Players to join a H
 - **Root Authority:** Anchor baked into PWA; signs [House Certificates](./house_certificate_contract.md).
 - [House Certificate](./house_certificate_contract.md): Signed by Root; validates House’s hosting authority and public key.
 - **House Device:** Holds private key referenced in Certificate; issues Join challenges.  
-- **Player Device:** Holds Player’s local keypair; computes responses using pairwise secret.  
+ - **Player Device:** Holds Player’s persistent P-256 keypair; derives Player UID as H(pubKey || houseId).
 
 ## Lifecycle & States
 1. **Challenge Issued:** House generates ephemeral challenge (nonce + time anchor + round binding).  
  2. **QR Display:** Challenge packaged with [House Certificate](./house_certificate_contract.md) and Round binding into Join QR.
 3. **Response Computed:** Player scans QR, validates Certificate, and computes signed response bound to challenge.
 4. **Verification:** House checks response validity and admits Player if seat available.
-5. **Ledger Entry:** Admission recorded with seat assignment and buy-in.
+5. **Ledger Entry:** House records `{ playerUid, seat, buyIn, ts, nonce }` using its clock (`ts`). Player devices accept ±5 min drift when validating time anchors.
 
 ## QR Payload Format
 - **Challenge QR:** Encodes a JSON object:
@@ -30,22 +30,20 @@ Provide a secure, offline-verifiable admission mechanism for Players to join a H
 }
 ```
 
-- **Player Response:** Returned payload (not necessarily QR) includes:
+- **Player Response:** Returned payload includes:
 
 ```json
 {
-  "player": "<uid>",
+  "playerUid": "<H(pubKey || houseId)>",
+  "playerPubKey": "<base64url p256 pubKey>",
   "round": "<round id>",
+  "seat": "<requested seat index>",
   "nonce": "<challenge nonce>",
-  "hmac": "<rolling code>",
-  "bankRef": "<optional receiptId>",
-  "sig": "<player signature>"
+  "sig_player": "<player signature>"
 }
 ```
 
-`bankRef` allows a Player to fund the buy-in with a stored [BANK Receipt](./bank_receipt_contract.md). When admission succeeds, this `bankRef` is logged and later embedded in the resulting [Bet Certificate](./bet_certificate_contract.md).
-
-All binary values—the House certificate's `signature`, the challenge `nonce`, the response `hmac`, and the Player `sig`—are base64url-encoded. Developers should use the shared helpers in `src/utils/base64.ts` (`bytesToBase64Url` / `base64UrlToBytes`) to handle these fields. The utilities abstract away environment differences by using browser `btoa`/`atob` when available and falling back to Node's `Buffer` APIs so the same code works across platforms.
+All binary values—the House certificate's `signature`, the challenge `nonce`, the `playerPubKey`, and the `sig_player`—are base64url-encoded. Developers should use the shared helpers in `src/utils/base64.ts` (`bytesToBase64Url` / `base64UrlToBytes`) to handle these fields. The utilities abstract away environment differences by using browser `btoa`/`atob` when available and falling back to Node's `Buffer` APIs so the same code works across platforms.
 
 ## QR Generation & Scanning
 - Join challenges, [Bet Certificates](./bet_certificate_contract.md) and [BANK Receipts](./bank_receipt_contract.md) can be rendered as QRs for portability. Helper modules in [`betCertQR.ts`](../src/betCertQR.ts) and [`bankReceiptQR.ts`](../src/bankReceiptQR.ts) generate data URL images and parse scanned payloads.
@@ -54,10 +52,10 @@ All binary values—the House certificate's `signature`, the challenge `nonce`, 
 
 ## Challenge Requirements
 - **Contents:**  
-  - House Certificate  
-  - Round identifier  
-  - Ephemeral challenge nonce  
-  - Time anchor (for drift checks)  
+  - House Certificate
+  - Round identifier
+  - Ephemeral challenge nonce
+  - Time anchor (±5 min drift tolerance)
 - **Rotation interval:** Frequent (≈10–15 seconds) to prevent reuse via screenshots.  
 - **Uniqueness:** Each nonce is single-use; once redeemed, cannot be reused.  
 - **Binding:** Explicitly tied to the round identifier; cannot be replayed across rounds.  
@@ -66,20 +64,18 @@ All binary values—the House certificate's `signature`, the challenge `nonce`, 
 - **Verification:**  
     - Validate [House Certificate](./house_certificate_contract.md) against Root (offline).
   - Confirm Certificate validity window.  
-- **Response Computation:**  
-  - Use pre-established pairwise secret (from Player ↔ House) to compute rolling code/HMAC.  
-  - Bind response to challenge nonce, round identifier, and seat request.
-    - Include Player device signature for integrity and optionally a `bankRef` if paying via [BANK Receipt](./bank_receipt_contract.md).
+  - **Response Computation:**
+    - Derive `playerUid = H(playerPubKey || houseId)` and sign `{ playerUid, playerPubKey, round, seat, nonce }` with the Player’s private key.
+    - Bind response to challenge nonce, round identifier, and seat request.
 
 ## House Verification
-- **Checks performed:**  
-  - Certificate chain valid.  
-  - Certificate not expired/revoked.  
-  - Challenge nonce is fresh and unused.
-  - Response matches expected rolling code within drift tolerance.
-  - Player signature validates against Player UID key.
-    - If `bankRef` present, associated [BANK Receipt](./bank_receipt_contract.md) is valid and unspent.
-  - Round seat count < 4.
+  - **Checks performed:**
+    - Certificate chain valid.
+    - Certificate not expired/revoked.
+    - Challenge nonce is fresh and unused.
+    - `playerUid` equals H(`playerPubKey` || `houseId`).
+    - `sig_player` verifies against `playerPubKey`.
+    - Round seat count < 4.
 - **Outcomes:**  
   - **Pass:** Player admitted; ledger entry created; Player allocated 4 credits at declared round valuation.
   - **Fail:** Player denied; UX shows error (expired cert, full seats, stale QR, etc.).
@@ -95,8 +91,9 @@ All binary values—the House certificate's `signature`, the challenge `nonce`, 
 - **Certificate expiry:** [House Certificates](./house_certificate_contract.md) may also expire; Players must wait for the House to renew before joining.
 
 ## [Ledger & Sync](./ledger_sync_contract.md)
-- **Admission record:** Round ID, Player UID, challenge nonce, admission timestamp, buy-in credits, seat index.  
-- **Normalization:** Buy-in reflected in global sync, subject to $1,440/player/round ceiling.  
+- **Admission record:** `{ playerUid, seat, buyIn, ts, nonce }` plus round ID.
+- **Time drift:** `ts` comes from the House clock; verifiers allow ±5 min drift relative to their local time.
+- **Normalization:** Buy-in reflected in global sync, subject to $1,440/player/round ceiling.
 - **Tamper-evident:** Admissions signed by House key to prevent retroactive manipulation.
 
 ## Error Semantics
@@ -111,9 +108,9 @@ All binary values—the House certificate's `signature`, the challenge `nonce`, 
 - **Offline verification:** Player can always confirm House Certificate validity without internet.  
 - **Replay protection:** Nonce single-use + rotation interval prevents photo/reuse.  
 - **Round binding:** Responses valid only for the round ID in the challenge.  
-- **Time correctness:** House is authoritative; Player drift tolerance enforced.  
-- **Non-forgeability:** Requires valid pairwise secret + Player signature + House key validation.  
-- **Privacy:** Player UID is pseudonymous per-House; no hardware fingerprinting.  
+ - **Time correctness:** House is authoritative; ±5 min Player drift tolerance enforced.
+ - **Non-forgeability:** Requires Player signature + House key validation.
+ - **Privacy:** Player UID is pseudonymous per-House; no hardware fingerprinting.
 
 ## Acceptance Criteria
 - **Valid path:** Active [House Certificate](./house_certificate_contract.md) + fresh challenge + valid response → Player admitted.


### PR DESCRIPTION
## Summary
- document player P-256 keypair and UID hashing
- define join response and ledger entry schemas
- note ±5 min drift handling

## Testing
- `npm run build`
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bc39efbcdc8322a9b90395b23559a9