### PR TITLE
fix: align house cert schema between docs and code

### DIFF
--- a/docs/house_certificate_contract.md
+++ b/docs/house_certificate_contract.md
@@ -29,7 +29,7 @@ Authorize a device/operator to run **House** features for Roll‑et. Enables hos
 - **Seat policy interaction:** Hosting constrained by global rules (default **max 4 players per round**).
 - **Clock tolerance:** Validity checks allow ±5 min drift.
 
-## Required Claims / Assertions (Conceptual)
+## Required Claims / Assertions
 
 - `houseId` – unique identifier for the House device.
 - `kid` – certificate identifier for rotation and revocation.
@@ -38,6 +38,22 @@ Authorize a device/operator to run **House** features for Roll‑et. Enables hos
 - `notAfter` – timestamp when the Cert lapses.
 - `roles` – capabilities granted to the device.
 - `signature` – Root Authority ES256 signature over the above fields.
+
+```ts
+interface HouseCertPayload {
+  houseId: string
+  kid: string
+  housePubKey: JsonWebKey
+  notBefore: number
+  notAfter: number
+  roles: string[]
+}
+
+interface HouseCert {
+  payload: HouseCertPayload
+  signature: string // base64url
+}
+```
 
 ## Issuance (Input/Output)
 

--- a/src/House.tsx
+++ b/src/House.tsx
@@ -41,14 +41,14 @@ export default function House() {
     } catch {}
   }, [])
 
-  // Enforce that houseKey public key matches HouseCert publicKeyJwk
+  // Enforce that houseKey public key matches HouseCert housePubKey
   React.useEffect(() => {
     (async () => {
       if (!houseKey || !houseCert) { setKeyMismatch(false); return }
       try {
         const jwk = await crypto.subtle.exportKey('jwk', houseKey.publicKey)
         const a = JSON.stringify({ kty: jwk.kty, crv: (jwk as any).crv, x: (jwk as any).x, y: (jwk as any).y })
-        const b = JSON.stringify({ kty: houseCert.payload.publicKeyJwk.kty, crv: (houseCert.payload.publicKeyJwk as any).crv, x: (houseCert.payload.publicKeyJwk as any).x, y: (houseCert.payload.publicKeyJwk as any).y })
+        const b = JSON.stringify({ kty: houseCert.payload.housePubKey.kty, crv: (houseCert.payload.housePubKey as any).crv, x: (houseCert.payload.housePubKey as any).x, y: (houseCert.payload.housePubKey as any).y })
         setKeyMismatch(a !== b)
       } catch { setKeyMismatch(true) }
     })()

--- a/src/__tests__/JoinScannerFallback.test.tsx
+++ b/src/__tests__/JoinScannerFallback.test.tsx
@@ -21,11 +21,12 @@ describe('JoinScanner fallback', () => {
     const secret = await subtle().generateKey({ name: 'HMAC', hash: 'SHA-256' }, true, ['sign'])
 
     const houseCert = await issueHouseCert({
-      subject: 'h1',
-      publicKeyJwk: await subtle().exportKey('jwk', house.publicKey),
-      nbf: Date.now() - 1000,
-      exp: Date.now() + 60_000,
-      capabilities: ['host rounds'],
+      houseId: 'h1',
+      kid: 'k1',
+      housePubKey: await subtle().exportKey('jwk', house.publicKey),
+      notBefore: Date.now() - 1000,
+      notAfter: Date.now() + 60_000,
+      roles: ['host rounds'],
     }, root.privateKey)
 
     const challenge = await createJoinChallenge(houseCert, 'r1')

--- a/src/__tests__/cert-encoding.test.ts
+++ b/src/__tests__/cert-encoding.test.ts
@@ -17,11 +17,12 @@ describe('certificate signature encoding utilities', () => {
     const root = await genKeyPair()
     const house = await genKeyPair()
     const payload = {
-      subject: 'house-1',
-      publicKeyJwk: await subtle().exportKey('jwk', house.publicKey),
-      nbf: Date.now() - 1000,
-      exp: Date.now() + 60_000,
-      capabilities: ['host rounds']
+      houseId: 'house-1',
+      kid: 'k1',
+      housePubKey: await subtle().exportKey('jwk', house.publicKey),
+      notBefore: Date.now() - 1000,
+      notAfter: Date.now() + 60_000,
+      roles: ['host rounds']
     }
     const data = encoder.encode(JSON.stringify(payload))
     const sigBuf = await subtle().sign({ name: 'ECDSA', hash: 'SHA-256' }, root.privateKey, data)

--- a/src/__tests__/certs.test.ts
+++ b/src/__tests__/certs.test.ts
@@ -16,11 +16,12 @@ describe('certificate flows', () => {
     const root = await genKeyPair()
     const houseKeys = await genKeyPair()
     const payload = {
-      subject: 'house-1',
-      publicKeyJwk: await subtle().exportKey('jwk', houseKeys.publicKey),
-      nbf: Date.now() - 1000,
-      exp: Date.now() + 60_000,
-      capabilities: ['host rounds']
+      houseId: 'house-1',
+      kid: 'k1',
+      housePubKey: await subtle().exportKey('jwk', houseKeys.publicKey),
+      notBefore: Date.now() - 1000,
+      notAfter: Date.now() + 60_000,
+      roles: ['host rounds']
     }
     const cert = await issueHouseCert(payload, root.privateKey)
     expect(await validateHouseCert(cert, root.publicKey)).toBe(true)

--- a/src/__tests__/qr.test.ts
+++ b/src/__tests__/qr.test.ts
@@ -16,11 +16,12 @@ describe('QR flows', () => {
     const root = await genKeyPair()
     const house = await genKeyPair()
     const houseCert = await issueHouseCert({
-      subject: 'h1',
-      publicKeyJwk: await subtle().exportKey('jwk', house.publicKey),
-      nbf: Date.now() - 1000,
-      exp: Date.now() + 60_000,
-      capabilities: ['host rounds']
+      houseId: 'h1',
+      kid: 'k1',
+      housePubKey: await subtle().exportKey('jwk', house.publicKey),
+      notBefore: Date.now() - 1000,
+      notAfter: Date.now() + 60_000,
+      roles: ['host rounds']
     }, root.privateKey)
     const challenge = await createJoinChallenge(houseCert, 'r1')
     const qr = await joinChallengeToQR(challenge)

--- a/src/certs/authorizedHouseCertLedger.ts
+++ b/src/certs/authorizedHouseCertLedger.ts
@@ -1,7 +1,8 @@
 import { HouseCert } from './houseCert'
 
 export interface AuthorizedHouseCertLedgerEntry {
-  subject: string
+  houseId: string
+  kid: string
   signature: string
 }
 
@@ -17,6 +18,9 @@ export const houseCertRootPublicKeyJwk: JsonWebKey = {
 
 export function isAuthorizedHouseCert(cert: HouseCert): boolean {
   return authorizedHouseCertLedger.some(
-    entry => entry.subject === cert.payload.subject && entry.signature === cert.signature
+    entry =>
+      entry.houseId === cert.payload.houseId &&
+      entry.kid === cert.payload.kid &&
+      entry.signature === cert.signature
   )
 }

--- a/src/certs/houseCert.ts
+++ b/src/certs/houseCert.ts
@@ -3,11 +3,12 @@ import { bytesToBase64Url, base64UrlToBytes } from '../utils/base64'
 const subtle = globalThis.crypto.subtle
 
 export interface HouseCertPayload {
-  subject: string
-  publicKeyJwk: JsonWebKey
-  nbf: number
-  exp: number
-  capabilities: string[]
+  houseId: string
+  kid: string
+  housePubKey: JsonWebKey
+  notBefore: number
+  notAfter: number
+  roles: string[]
 }
 
 export interface HouseCert {
@@ -37,6 +38,6 @@ export async function issueHouseCert(payload: HouseCertPayload, rootKey: CryptoK
 
 export async function validateHouseCert(cert: HouseCert, rootKey: CryptoKey, now: number = Date.now()): Promise<boolean> {
   const { payload, signature } = cert
-  if (now < payload.nbf || now > payload.exp) return false
+  if (now < payload.notBefore || now > payload.notAfter) return false
   return verifyPayload(payload, signature, rootKey)
 }

--- a/src/hooks/useJoin.ts
+++ b/src/hooks/useJoin.ts
@@ -64,7 +64,7 @@ export function useJoin(){
         if (!valid) return
         const key = await crypto.subtle.importKey(
           'jwk',
-          challenge.houseCert.payload.publicKeyJwk,
+          challenge.houseCert.payload.housePubKey,
           { name: 'ECDSA', namedCurve: 'P-256' },
           true,
           ['verify']


### PR DESCRIPTION
## Summary
- document House certificate payload fields and interfaces
- align HouseCertPayload and ledger to houseId/kid/notBefore/notAfter schema
- adjust host/join flows and tests to reference housePubKey and roles

## Testing
- `npm run build`
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bc39ae9a30832286306b858913ece7