### PR TITLE
docs: expand ledger sync contract

### DIFF
--- a/docs/ledger_sync_contract.md
+++ b/docs/ledger_sync_contract.md
@@ -1,66 +1,119 @@
 # Roll-et — Ledger & Sync Contract
 
 ## Purpose
+
 Maintain a complete, tamper-evident record of all House operations (rounds, admissions, bets, certs, receipts, outcomes). Ensure periodic synchronization of these records with the Roll-et authority backend, while enforcing global normalization rules and license validity.
 
 ## Trust Chain & Roles
+
 - **Root Authority:** Anchor baked into PWA; issues [House Certificates](./house_certificate_contract.md); operates backend sync endpoint.
 - [House Certificate](./house_certificate_contract.md): Active license required for ledger sync.
-- **House Device:** Maintains local append-only ledger; uploads batches during sync.  
-- **Player Devices:** Reference local ledger entries (admissions, certs, receipts) but do not maintain global sync.  
+- **House Device:** Maintains local append-only ledger; uploads batches during sync.
+- **Player Devices:** Reference local ledger entries (admissions, certs, receipts) but do not maintain global sync.
 
 ## Ledger Scope
-Each ledger entry MUST capture the authoritative state of Player interaction with a round. Minimum fields (conceptual):  
-  - House identity (via [House Certificate](./house_certificate_contract.md)).
-  - Round ID + valuation.
-  - Admission events (Player UID, seat assignment, buy-in credits) via [Join Challenge/Response](./join_challenge_response_contract.md).
-  - Bets (normalized slips, wagered credits, counters).
-  - Lock events (bet hashes, [Bet Certificate](./bet_certificate_contract.md) issuance).
-  - Results (winning number, odds applied).
-  - Settlements (net value, disposition = tender/banked).
-  - [BANK Receipts](./bank_receipt_contract.md) (issued, spent, IDs).
-  - Errors/rejections (optional, for audit).
+
+Each ledger entry MUST capture the authoritative state of Player interaction with a round. Minimum fields (conceptual):
+
+- House identity (via [House Certificate](./house_certificate_contract.md)).
+- Round ID + valuation.
+- Admission events (Player UID, seat assignment, buy-in credits) via [Join Challenge/Response](./join_challenge_response_contract.md).
+- Bets (normalized slips, wagered credits, counters).
+- Lock events (bet hashes, [Bet Certificate](./bet_certificate_contract.md) issuance).
+- Results (winning number, odds applied).
+- Settlements (net value, disposition = tender/banked).
+- [BANK Receipts](./bank_receipt_contract.md) (issued, spent, IDs).
+- Errors/rejections (optional, for audit).
 
 ## Local Ledger Properties
-- **Append-only:** No deletions or retroactive edits allowed.  
-- **Tamper-evident:** Each entry references prior hash or sequence ID.  
-- **Authoritative:** House ledger is canonical for its rounds.  
-- **Storage:** Retained locally for full history.  
+
+- **Append-only:** No deletions or retroactive edits allowed.
+- **Tamper-evident:** Each entry references prior hash or sequence ID.
+- **Authoritative:** House ledger is canonical for its rounds.
+- **Storage:** Retained locally for full history.
+
+## Ledger Entry Format
+
+Every ledger entry is a hash-chained object:
+
+```json
+{
+  "entryId": string,      // SHA-256 over prevHash|type|payload|ts
+  "prevHash": string|null,
+  "type": string,
+  "payload": object,
+  "ts": number            // milliseconds since epoch
+}
+```
+
+- `entryId` hashes the prior hash, event type, payload and timestamp.
+- `prevHash` links to the previous `entryId`, creating a tamper-evident chain.
+- `ts` records when the entry was appended.
+
+### Ledger Event Payloads
+
+Event types and their payload fields:
+
+- **`join_challenge_issued`** `{ round, nonce, nbf, exp }` — QR challenge parameters.
+- **`admission`** `{ seat, player?, name?, round?, method? }` — seat assignment with optional identifiers or join method.
+- **`round_locked`** `{ seatCount, maxSeats, players: [{ id, stake }] }` — round start snapshot.
+- **`bet_cert_issued`** `{ player, certId, betHash, exp }` — issued Bet Certificate details.
+- **`round_settled`** `{ roll, deltas }` — winning roll and per-seat credit changes.
+- **`receipt_issued`** `{ player, value, betCertRef, receiptId?, spendCode? }` — BANK receipt issuance.
+- **`receipt_spent`** `{ receiptId, player, value, method? }` — receipt redemption record.
 
 ## Sync Process
-- **Trigger:** Periodic or on-demand (House operator action).  
+
+- **Trigger:** Periodic or on-demand (House operator action).
 - **Prerequisite:** Active [House Certificate](./house_certificate_contract.md) required.
-- **Batching:** House transmits append-only segment since last sync.  
-- **Verification by backend:**  
-  - Cert validity (Root → House).  
-  - Entry integrity (sequential hash chain intact).  
-  - No duplication (idsempotent merges).  
-- **Outcome:** Entries merged into global ledger under that House UID.  
+- **Batching:** House transmits append-only segment since last sync.
+- **Verification by backend:**
+  - Cert validity (Root → House).
+  - Entry integrity (sequential hash chain intact).
+  - No duplication (idsempotent merges).
+- **Outcome:** Entries merged into global ledger under that House UID.
+
+## Checkpoints & Signed Sync Export
+
+- **Checkpoint entries:** Special ledger records marking the last synced `entryId`. They anchor future batches and remain in the hash chain.
+- **SyncExportHeader:** Before upload, the House signs a header containing the current House Cert `kid`, range (`startEntryId` → `endEntryId`), and a timestamp. Backend verifies the signature against the presented House Cert before accepting the batch.
+
+## House Certificate Lifecycle & Sync Eligibility
+
+- **VALID/WARNING:** Ledger sync permitted.
+- **LAPSED_SOFT:** Read-only; previously recorded entries may sync after renewal but no new entries can be uploaded.
+- **EXPIRED/REVOKED:** Sync rejected. House must renew to resume syncing.
+- Backend enforces that every entry's timestamp falls within a period covered by a valid certificate.
 
 ## Global Normalization Rules
-- **Ceiling:** Analytics cap at **$1,440 max per player per round** (8 credits × 18:1 × $10).  
-- **Local play variance:** Houses may declare any valuation in range, but sync collapses to the normalization ceiling.  
-- **Comparability:** Ensures fair global analytics regardless of local stakes.  
+
+- **Ceiling:** Analytics cap at **$1,440 max per player per round** (8 credits × 18:1 × $10).
+- **Local play variance:** Houses may declare any valuation in range, but sync collapses to the normalization ceiling.
+- **Comparability:** Ensures fair global analytics regardless of local stakes.
 
 ## Error Handling
-- **Invalid Cert:** Sync refused; House must renew.  
-- **Broken hash chain:** Sync refused; operator warned of tamper/inconsistency.  
-- **Duplicate batch:** Ignored gracefully (idempotent).  
-- **Partial failure:** Affected entries flagged; House can retry.  
+
+- **Invalid Cert:** Sync refused; House must renew.
+- **Broken hash chain:** Sync refused; operator warned of tamper/inconsistency.
+- **Duplicate batch:** Ignored gracefully (idempotent).
+- **Partial failure:** Affected entries flagged; House can retry.
 
 ## Replay & Integrity
-- **Admission nonces, Cert IDs, Receipt IDs** prevent replay across syncs.  
-- **Sequential ordering** ensures no gaps.  
-- **Auditability:** Backend stores full history, immutable, with references to Cert identities.  
+
+- **Admission nonces, Cert IDs, Receipt IDs** prevent replay across syncs.
+- **Sequential ordering** ensures no gaps.
+- **Auditability:** Backend stores full history, immutable, with references to Cert identities.
 
 ## Security Invariants
-- **License gating:** Sync only accepted from Houses with active Certificates.  
-- **Non-forgeability:** Entries signed by House private key; backend rejects unsigned or invalid.  
-- **Immutability:** Once synced, entries cannot be altered or deleted.  
-- **Privacy:** Player IDs are pseudonymous, per-House; no PII in global ledger.  
+
+- **License gating:** Sync only accepted from Houses with active Certificates.
+- **Non-forgeability:** Entries signed by House private key; backend rejects unsigned or invalid.
+- **Immutability:** Once synced, entries cannot be altered or deleted.
+- **Privacy:** Player IDs are pseudonymous, per-House; no PII in global ledger.
 
 ## Acceptance Criteria
-- **Valid sync:** New ledger entries append cleanly; backend acknowledges.  
-- **Invalid sync:** Errors reported with cause (invalid cert, tamper, replay).  
-- **Global analytics:** Always respect $1,440 normalization ceiling.  
-- **Audit:** Every House’s full ledger traceable to Cert identity and Root authority.  
+
+- **Valid sync:** New ledger entries append cleanly; backend acknowledges.
+- **Invalid sync:** Errors reported with cause (invalid cert, tamper, replay).
+- **Global analytics:** Always respect $1,440 normalization ceiling.
+- **Audit:** Every House’s full ledger traceable to Cert identity and Root authority.


### PR DESCRIPTION
## Summary
- specify hash-chained ledger entry format
- enumerate ledger event payloads and fields
- outline checkpoints, SyncExportHeader, and certificate-based sync gating

## Testing
- `npm run build`
- `npm test -- --run`
- `npm run lint || true`


------
https://chatgpt.com/codex/tasks/task_e_68bc3e437e5483229d20fd82dc88a3ee