### PR TITLE
fix(join): align join response with docs

### DIFF
--- a/src/House.tsx
+++ b/src/House.tsx
@@ -1,110 +1,165 @@
-import React from 'react'
-import { Link } from 'react-router-dom'
-import { usePlayers, useRoundState, useStats, PER_ROUND_POOL, useHouse } from './context/GameContext'
-import { fmtUSDSign } from './utils'
-import { useInstallPrompt } from './pwa/useInstallPrompt'
-import { lockRound } from './round'
-import { appendLedger } from './ledger/localLedger'
-import type { HouseCert } from './certs/houseCert'
-import { createJoinChallenge, joinChallengeToQR, type JoinChallenge } from './join'
-import { betCertToQR } from './betCertQR'
-import { MAX_SEATS } from './config'
-import JoinResponseScanner from './components/JoinResponseScanner'
-import BankReceiptScanner from './components/BankReceiptScanner'
-import { verifyBankReceipt } from './certs/bankReceipt'
-import PairingScanner from './components/PairingScanner'
-import { base64UrlToBytes } from './utils/base64'
-import { verifyJoinTotp } from './utils/totp'
+import React from 'react';
+import { Link } from 'react-router-dom';
+import {
+  usePlayers,
+  useRoundState,
+  useStats,
+  PER_ROUND_POOL,
+  useHouse,
+} from './context/GameContext';
+import { fmtUSDSign } from './utils';
+import { useInstallPrompt } from './pwa/useInstallPrompt';
+import { lockRound } from './round';
+import { appendLedger } from './ledger/localLedger';
+import type { HouseCert } from './certs/houseCert';
+import {
+  createJoinChallenge,
+  joinChallengeToQR,
+  type JoinChallenge,
+  verifyJoinResponse,
+} from './join';
+import { betCertToQR } from './betCertQR';
+import { MAX_SEATS } from './config';
+import JoinResponseScanner from './components/JoinResponseScanner';
+import BankReceiptScanner from './components/BankReceiptScanner';
+import { verifyBankReceipt } from './certs/bankReceipt';
+import PairingScanner from './components/PairingScanner';
+import { base64UrlToBytes } from './utils/base64';
+import { verifyJoinTotp } from './utils/totp';
 
 export default function House() {
-  const { players, setPlayers } = usePlayers()
-  const { roundState, setRoundState } = useRoundState()
-  const { stats } = useStats()
-  const { canInstall, install, installed } = useInstallPrompt()
-  const { houseKey, setBetCerts, receipts } = useHouse()
-  const [houseCert, setHouseCert] = React.useState<HouseCert | null>(null)
-  const [joinQR, setJoinQR] = React.useState('')
-  const [betCertQRs, setBetCertQRs] = React.useState<Array<{ player: string; qr: string }>>([])
-  const [newPlayerName, setNewPlayerName] = React.useState('')
-  const [scanningJoinResp, setScanningJoinResp] = React.useState(false)
-  const [scanningSpend, setScanningSpend] = React.useState(false)
-  const [spendCodeInput, setSpendCodeInput] = React.useState('')
-  const [lastChallenge, setLastChallenge] = React.useState<JoinChallenge | null>(null)
-  const [keyMismatch, setKeyMismatch] = React.useState(false)
-  const [scanningPair, setScanningPair] = React.useState(false)
-  const [totpInput, setTotpInput] = React.useState('')
+  const { players, setPlayers } = usePlayers();
+  const { roundState, setRoundState } = useRoundState();
+  const { stats } = useStats();
+  const { canInstall, install, installed } = useInstallPrompt();
+  const { houseKey, setBetCerts, receipts } = useHouse();
+  const [houseCert, setHouseCert] = React.useState<HouseCert | null>(null);
+  const [joinQR, setJoinQR] = React.useState('');
+  const [betCertQRs, setBetCertQRs] = React.useState<
+    Array<{ player: string; qr: string }>
+  >([]);
+  const [newPlayerName, setNewPlayerName] = React.useState('');
+  const [scanningJoinResp, setScanningJoinResp] = React.useState(false);
+  const [scanningSpend, setScanningSpend] = React.useState(false);
+  const [spendCodeInput, setSpendCodeInput] = React.useState('');
+  const [lastChallenge, setLastChallenge] =
+    React.useState<JoinChallenge | null>(null);
+  const [keyMismatch, setKeyMismatch] = React.useState(false);
+  const [scanningPair, setScanningPair] = React.useState(false);
+  const [totpInput, setTotpInput] = React.useState('');
 
   React.useEffect(() => {
     try {
-      const raw = localStorage.getItem('houseCert')
-      if (raw) setHouseCert(JSON.parse(raw) as HouseCert)
+      const raw = localStorage.getItem('houseCert');
+      if (raw) setHouseCert(JSON.parse(raw) as HouseCert);
     } catch {}
-  }, [])
+  }, []);
 
   // Enforce that houseKey public key matches HouseCert housePubKey
   React.useEffect(() => {
     (async () => {
-      if (!houseKey || !houseCert) { setKeyMismatch(false); return }
+      if (!houseKey || !houseCert) {
+        setKeyMismatch(false);
+        return;
+      }
       try {
-        const jwk = await crypto.subtle.exportKey('jwk', houseKey.publicKey)
-        const a = JSON.stringify({ kty: jwk.kty, crv: (jwk as any).crv, x: (jwk as any).x, y: (jwk as any).y })
-        const b = JSON.stringify({ kty: houseCert.payload.housePubKey.kty, crv: (houseCert.payload.housePubKey as any).crv, x: (houseCert.payload.housePubKey as any).x, y: (houseCert.payload.housePubKey as any).y })
-        setKeyMismatch(a !== b)
-      } catch { setKeyMismatch(true) }
-    })()
-  }, [houseKey, houseCert])
+        const jwk = await crypto.subtle.exportKey('jwk', houseKey.publicKey);
+        const a = JSON.stringify({
+          kty: jwk.kty,
+          crv: (jwk as any).crv,
+          x: (jwk as any).x,
+          y: (jwk as any).y,
+        });
+        const b = JSON.stringify({
+          kty: houseCert.payload.housePubKey.kty,
+          crv: (houseCert.payload.housePubKey as any).crv,
+          x: (houseCert.payload.housePubKey as any).x,
+          y: (houseCert.payload.housePubKey as any).y,
+        });
+        setKeyMismatch(a !== b);
+      } catch {
+        setKeyMismatch(true);
+      }
+    })();
+  }, [houseKey, houseCert]);
 
   const newRound = () => {
-    setPlayers(prev => prev.map(p => ({ ...p, pool: PER_ROUND_POOL, bets: [] })))
-    setRoundState('open')
-    setBetCertQRs([])
-    setBetCerts({})
-  }
+    setPlayers((prev) =>
+      prev.map((p) => ({ ...p, pool: PER_ROUND_POOL, bets: [] })),
+    );
+    setRoundState('open');
+    setBetCertQRs([]);
+    setBetCerts({});
+  };
 
   const lock = async () => {
-    if (!houseKey) return
-    if (keyMismatch) { alert('House signing key does not match House Certificate public key. Cannot lock.'); return }
-    setRoundState('locked')
-    const roundId = String(stats.rounds + 1)
-    await appendLedger('round_locked', roundId, { seatCount: players.length, maxSeats: MAX_SEATS, players: players.map(p => ({ id: p.id, stake: p.bets.reduce((a,b)=>a+b.amount,0) })) })
-    const certs = await lockRound(players, houseKey.privateKey, roundId)
-    const qrs = await Promise.all(
-      certs.map(async c => ({ player: c.player, qr: await betCertToQR(c) }))
-    )
-    setBetCertQRs(qrs)
-    setBetCerts(certs.reduce<Record<number, string>>((acc, c) => {
-      acc[Number(c.player)] = c.certId
-      return acc
-    }, {}))
-    for (const c of certs) {
-      await appendLedger('bet_cert_issued', roundId, { player: c.player, certId: c.certId, betHash: c.betHash, exp: c.exp })
+    if (!houseKey) return;
+    if (keyMismatch) {
+      alert(
+        'House signing key does not match House Certificate public key. Cannot lock.',
+      );
+      return;
     }
-  }
+    setRoundState('locked');
+    const roundId = String(stats.rounds + 1);
+    await appendLedger('round_locked', roundId, {
+      seatCount: players.length,
+      maxSeats: MAX_SEATS,
+      players: players.map((p) => ({
+        id: p.id,
+        stake: p.bets.reduce((a, b) => a + b.amount, 0),
+      })),
+    });
+    const certs = await lockRound(players, houseKey.privateKey, roundId);
+    const qrs = await Promise.all(
+      certs.map(async (c) => ({ player: c.player, qr: await betCertToQR(c) })),
+    );
+    setBetCertQRs(qrs);
+    setBetCerts(
+      certs.reduce<Record<number, string>>((acc, c) => {
+        acc[Number(c.player)] = c.certId;
+        return acc;
+      }, {}),
+    );
+    for (const c of certs) {
+      await appendLedger('bet_cert_issued', roundId, {
+        player: c.player,
+        certId: c.certId,
+        betHash: c.betHash,
+        exp: c.exp,
+      });
+    }
+  };
 
   const makeJoinQR = async () => {
-    if (!houseCert) return
-    const challenge = await createJoinChallenge(houseCert, String(stats.rounds + 1))
-    const qr = await joinChallengeToQR(challenge)
-    setJoinQR(qr)
-    setLastChallenge(challenge)
-  }
+    if (!houseCert) return;
+    const challenge = await createJoinChallenge(
+      houseCert,
+      String(stats.rounds + 1),
+    );
+    const qr = await joinChallengeToQR(challenge);
+    setJoinQR(qr);
+    setLastChallenge(challenge);
+  };
 
   const addSeat = async () => {
-    const occupied = new Set(players.map(p => p.id))
-    const seat = Array.from({ length: MAX_SEATS }, (_, i) => i + 1).find(n => !occupied.has(n))
-    if (!seat) return
-    const name = newPlayerName.trim()
-    if (!name) return
+    const occupied = new Set(players.map((p) => p.id));
+    const seat = Array.from({ length: MAX_SEATS }, (_, i) => i + 1).find(
+      (n) => !occupied.has(n),
+    );
+    if (!seat) return;
+    const name = newPlayerName.trim();
+    if (!name) return;
     // Add locally
-    setPlayers(prev => {
-      if (prev.some(p => p.id === seat)) return prev
-      const np = { id: seat, name, bets: [], pool: PER_ROUND_POOL, bank: 0 }
-      return [...prev, np].sort((a, b) => a.id - b.id)
-    })
+    setPlayers((prev) => {
+      if (prev.some((p) => p.id === seat)) return prev;
+      const np = { id: seat, name, bets: [], pool: PER_ROUND_POOL, bank: 0 };
+      return [...prev, np].sort((a, b) => a.id - b.id);
+    });
     // Log admission to ledger for the upcoming round
-    await appendLedger('admission', String(stats.rounds + 1), { seat, name })
-    setNewPlayerName('')
-  }
+    await appendLedger('admission', String(stats.rounds + 1), { seat, name });
+    setNewPlayerName('');
+  };
 
   return (
     <div className="container">
@@ -118,15 +173,21 @@ export default function House() {
         <div className="amount">
           <div>
             <strong>Round State:</strong>{' '}
-            <span className={`roundstate ${roundState}`}>{roundState.toUpperCase()}</span>
+            <span className={`roundstate ${roundState}`}>
+              {roundState.toUpperCase()}
+            </span>
           </div>
           <div className="ctrl-btns">
             <button onClick={lock}>Lock</button>
             <button onClick={() => setRoundState('settled')}>Settle</button>
             <button onClick={newRound}>New Round</button>
             <button onClick={makeJoinQR}>Join QR</button>
-            <button onClick={() => setScanningJoinResp(true)}>Scan Join Response</button>
-            <button onClick={() => setScanningSpend(true)}>Spend Receipt</button>
+            <button onClick={() => setScanningJoinResp(true)}>
+              Scan Join Response
+            </button>
+            <button onClick={() => setScanningSpend(true)}>
+              Spend Receipt
+            </button>
             <button onClick={() => setScanningPair(true)}>Scan Pairing</button>
           </div>
           <div className="manual-roll">
@@ -134,75 +195,159 @@ export default function House() {
               type="text"
               placeholder="Spend code (10 digits)"
               value={spendCodeInput}
-              onChange={e => setSpendCodeInput(e.target.value.replace(/\D/g, '').slice(0, 10))}
+              onChange={(e) =>
+                setSpendCodeInput(
+                  e.target.value.replace(/\D/g, '').slice(0, 10),
+                )
+              }
             />
-            <button onClick={async () => {
-              const code = spendCodeInput
-              if (code.length < 10) return
-                const rec = receipts.find(r => r.spendCode && r.spendCode === code)
-                if (!rec) { alert('Receipt not found for code.'); return }
-                const ok = await verifyBankReceipt(rec.receipt, houseKey!.publicKey)
-                if (!ok) { alert('Invalid or expired receipt'); return }
-                const spentKey = 'roll_et_spent_receipts'
+            <button
+              onClick={async () => {
+                const code = spendCodeInput;
+                if (code.length < 10) return;
+                const rec = receipts.find(
+                  (r) => r.spendCode && r.spendCode === code,
+                );
+                if (!rec) {
+                  alert('Receipt not found for code.');
+                  return;
+                }
+                const ok = await verifyBankReceipt(
+                  rec.receipt,
+                  houseKey!.publicKey,
+                );
+                if (!ok) {
+                  alert('Invalid or expired receipt');
+                  return;
+                }
+                const spentKey = 'roll_et_spent_receipts';
                 try {
-                  const raw = localStorage.getItem(spentKey)
-                  const set = new Set<string>(raw ? JSON.parse(raw) as string[] : [])
-                  if (set.has(rec.receipt.receiptId)) { alert('Receipt already spent.'); return }
-                  await appendLedger('receipt_spent', String(stats.rounds + 1), {
-                    receiptId: rec.receipt.receiptId,
-                    playerUidThumbprint: rec.receipt.playerUidThumbprint,
-                    amount: rec.receipt.amount,
-                    kind: rec.receipt.kind,
-                    method: 'code',
-                  })
-                  set.add(rec.receipt.receiptId)
-                  localStorage.setItem(spentKey, JSON.stringify(Array.from(set)))
-                  alert('Receipt marked as spent.')
-                  setSpendCodeInput('')
-                } catch { alert('Failed to record spend.'); }
-            }}>Spend by code</button>
+                  const raw = localStorage.getItem(spentKey);
+                  const set = new Set<string>(
+                    raw ? (JSON.parse(raw) as string[]) : [],
+                  );
+                  if (set.has(rec.receipt.receiptId)) {
+                    alert('Receipt already spent.');
+                    return;
+                  }
+                  await appendLedger(
+                    'receipt_spent',
+                    String(stats.rounds + 1),
+                    {
+                      receiptId: rec.receipt.receiptId,
+                      playerUidThumbprint: rec.receipt.playerUidThumbprint,
+                      amount: rec.receipt.amount,
+                      kind: rec.receipt.kind,
+                      method: 'code',
+                    },
+                  );
+                  set.add(rec.receipt.receiptId);
+                  localStorage.setItem(
+                    spentKey,
+                    JSON.stringify(Array.from(set)),
+                  );
+                  alert('Receipt marked as spent.');
+                  setSpendCodeInput('');
+                } catch {
+                  alert('Failed to record spend.');
+                }
+              }}
+            >
+              Spend by code
+            </button>
           </div>
           <div className="manual-roll">
             <input
               type="text"
               placeholder="Join TOTP (6 digits)"
               value={totpInput}
-              onChange={e => setTotpInput(e.target.value.replace(/\D/g, '').slice(0, 6))}
+              onChange={(e) =>
+                setTotpInput(e.target.value.replace(/\D/g, '').slice(0, 6))
+              }
               disabled={!lastChallenge}
             />
-            <button onClick={async () => {
-              if (!totpInput || !lastChallenge) return
-              try {
-                const raw = localStorage.getItem('roll_et_pair_secrets')
-                const map = raw ? (JSON.parse(raw) as Record<string, string>) : {}
-                let matched: string | null = null
-                for (const [pid, b64] of Object.entries(map)) {
-                  const ok = await verifyJoinTotp(totpInput, base64UrlToBytes(b64) as Uint8Array, lastChallenge.round, lastChallenge.nonce, lastChallenge.nbf, 60_000, 1)
-                  if (ok) { matched = pid; break }
+            <button
+              onClick={async () => {
+                if (!totpInput || !lastChallenge) return;
+                try {
+                  const raw = localStorage.getItem('roll_et_pair_secrets');
+                  const map = raw
+                    ? (JSON.parse(raw) as Record<string, string>)
+                    : {};
+                  let matched: string | null = null;
+                  for (const [pid, b64] of Object.entries(map)) {
+                    const ok = await verifyJoinTotp(
+                      totpInput,
+                      base64UrlToBytes(b64) as Uint8Array,
+                      lastChallenge.round,
+                      lastChallenge.nonce,
+                      lastChallenge.nbf,
+                      60_000,
+                      1,
+                    );
+                    if (ok) {
+                      matched = pid;
+                      break;
+                    }
+                  }
+                  if (!matched) {
+                    alert('No matching pairing secret for TOTP.');
+                    return;
+                  }
+                  const occupied = new Set(players.map((p) => p.id));
+                  const seat = Array.from(
+                    { length: MAX_SEATS },
+                    (_, i) => i + 1,
+                  ).find((n) => !occupied.has(n));
+                  if (seat) {
+                    setPlayers((prev) =>
+                      [
+                        ...prev,
+                        {
+                          id: seat,
+                          name: matched!,
+                          bets: [],
+                          pool: PER_ROUND_POOL,
+                          bank: 0,
+                        },
+                      ].sort((a, b) => a.id - b.id),
+                    );
+                    await appendLedger('admission', String(stats.rounds + 1), {
+                      seat,
+                      player: matched!,
+                      round: lastChallenge.round,
+                      method: 'totp',
+                    });
+                    setTotpInput('');
+                  }
+                } catch {
+                  alert('Admission by TOTP failed.');
                 }
-                if (!matched) { alert('No matching pairing secret for TOTP.'); return }
-                const occupied = new Set(players.map(p => p.id))
-                const seat = Array.from({ length: MAX_SEATS }, (_, i) => i + 1).find(n => !occupied.has(n))
-                if (seat) {
-                  setPlayers(prev => [...prev, { id: seat, name: matched!, bets: [], pool: PER_ROUND_POOL, bank: 0 }].sort((a,b)=>a.id-b.id))
-                  await appendLedger('admission', String(stats.rounds + 1), { seat, player: matched!, round: lastChallenge.round, method: 'totp' })
-                  setTotpInput('')
-                }
-              } catch { alert('Admission by TOTP failed.') }
-            }}>Admit by code</button>
+              }}
+            >
+              Admit by code
+            </button>
           </div>
           {keyMismatch && (
-            <div className="error" role="alert">Signing key does not match House Certificate. Lock/settle disabled.</div>
+            <div className="error" role="alert">
+              Signing key does not match House Certificate. Lock/settle
+              disabled.
+            </div>
           )}
           <div className="add-seat">
             <input
               type="text"
               placeholder={`Add player (max ${MAX_SEATS})`}
               value={newPlayerName}
-              onChange={e => setNewPlayerName(e.target.value)}
+              onChange={(e) => setNewPlayerName(e.target.value)}
               disabled={players.length >= MAX_SEATS}
             />
-            <button onClick={addSeat} disabled={!newPlayerName.trim() || players.length >= MAX_SEATS}>Add Seat</button>
+            <button
+              onClick={addSeat}
+              disabled={!newPlayerName.trim() || players.length >= MAX_SEATS}
+            >
+              Add Seat
+            </button>
           </div>
         </div>
       </section>
@@ -216,36 +361,66 @@ export default function House() {
 
       {scanningJoinResp && (
         <section className="bets">
-          <JoinResponseScanner onResponse={async (resp) => {
-            // Minimal admission: assign next available seat and log
-            if (!lastChallenge || resp.round !== lastChallenge.round || resp.nonce !== lastChallenge.nonce) {
-              alert('Join response does not match current challenge.')
-              setScanningJoinResp(false)
-              return
-            }
-            const occupied = new Set(players.map(p => p.id))
-            const seat = Array.from({ length: MAX_SEATS }, (_, i) => i + 1).find(n => !occupied.has(n))
-            if (seat) {
-              setPlayers(prev => [...prev, { id: seat, name: resp.player, bets: [], pool: PER_ROUND_POOL, bank: 0 }].sort((a,b)=>a.id-b.id))
-              await appendLedger('admission', String(stats.rounds + 1), { seat, player: resp.player, round: resp.round })
-            }
-            setScanningJoinResp(false)
-          }} />
+          <JoinResponseScanner
+            onResponse={async (resp) => {
+              if (
+                !lastChallenge ||
+                !(await verifyJoinResponse(resp, lastChallenge))
+              ) {
+                alert('Join response does not match current challenge.');
+                setScanningJoinResp(false);
+                return;
+              }
+              const occupied = new Set(players.map((p) => p.id));
+              const seat = Array.from(
+                { length: MAX_SEATS },
+                (_, i) => i + 1,
+              ).find((n) => !occupied.has(n));
+              if (seat) {
+                const alias = resp.alias || resp.playerUid;
+                setPlayers((prev) =>
+                  [
+                    ...prev,
+                    {
+                      id: seat,
+                      name: alias,
+                      bets: [],
+                      pool: PER_ROUND_POOL,
+                      bank: 0,
+                    },
+                  ].sort((a, b) => a.id - b.id),
+                );
+                await appendLedger('admission', String(stats.rounds + 1), {
+                  seat,
+                  player: alias,
+                  round: resp.round,
+                });
+              }
+              setScanningJoinResp(false);
+            }}
+          />
         </section>
       )}
 
       {scanningPair && (
         <section className="bets">
-          <PairingScanner onPair={async (p) => {
-            try {
-              const raw = localStorage.getItem('roll_et_pair_secrets')
-              const map = raw ? (JSON.parse(raw) as Record<string, string>) : {}
-              map[p.playerId] = p.secret
-              localStorage.setItem('roll_et_pair_secrets', JSON.stringify(map))
-              alert(`Paired with ${p.playerId}`)
-            } catch {}
-            setScanningPair(false)
-          }} />
+          <PairingScanner
+            onPair={async (p) => {
+              try {
+                const raw = localStorage.getItem('roll_et_pair_secrets');
+                const map = raw
+                  ? (JSON.parse(raw) as Record<string, string>)
+                  : {};
+                map[p.playerId] = p.secret;
+                localStorage.setItem(
+                  'roll_et_pair_secrets',
+                  JSON.stringify(map),
+                );
+                alert(`Paired with ${p.playerId}`);
+              } catch {}
+              setScanningPair(false);
+            }}
+          />
         </section>
       )}
 
@@ -254,23 +429,29 @@ export default function House() {
           <BankReceiptScanner
             housePublicKey={houseKey.publicKey}
             onReceipt={async (receipt) => {
-              const ok = await verifyBankReceipt(receipt, houseKey.publicKey)
-              if (!ok) { alert('Invalid or expired receipt'); setScanningSpend(false); return }
-                await appendLedger('receipt_spent', String(stats.rounds + 1), {
-                  receiptId: receipt.receiptId,
-                  playerUidThumbprint: receipt.playerUidThumbprint,
-                  amount: receipt.amount,
-                  kind: receipt.kind,
-                })
+              const ok = await verifyBankReceipt(receipt, houseKey.publicKey);
+              if (!ok) {
+                alert('Invalid or expired receipt');
+                setScanningSpend(false);
+                return;
+              }
+              await appendLedger('receipt_spent', String(stats.rounds + 1), {
+                receiptId: receipt.receiptId,
+                playerUidThumbprint: receipt.playerUidThumbprint,
+                amount: receipt.amount,
+                kind: receipt.kind,
+              });
               try {
-                const key = 'roll_et_spent_receipts'
-                const raw = localStorage.getItem(key)
-                const set = new Set<string>(raw ? JSON.parse(raw) as string[] : [])
-                set.add(receipt.receiptId)
-                localStorage.setItem(key, JSON.stringify(Array.from(set)))
+                const key = 'roll_et_spent_receipts';
+                const raw = localStorage.getItem(key);
+                const set = new Set<string>(
+                  raw ? (JSON.parse(raw) as string[]) : [],
+                );
+                set.add(receipt.receiptId);
+                localStorage.setItem(key, JSON.stringify(Array.from(set)));
               } catch {}
-              alert('Receipt marked as spent.')
-              setScanningSpend(false)
+              alert('Receipt marked as spent.');
+              setScanningSpend(false);
             }}
           />
         </section>
@@ -279,15 +460,17 @@ export default function House() {
       {betCertQRs.length > 0 && (
         <section className="bets">
           <h3>Bet Certs</h3>
-          {betCertQRs.map(b => {
-            const seatId = Number(b.player)
-            const label = players.find(p => p.id === seatId)?.name
+          {betCertQRs.map((b) => {
+            const seatId = Number(b.player);
+            const label = players.find((p) => p.id === seatId)?.name;
             return (
               <div key={b.player}>
-                <div>{label ? `${label} (Seat ${seatId})` : `Seat ${seatId}`}</div>
+                <div>
+                  {label ? `${label} (Seat ${seatId})` : `Seat ${seatId}`}
+                </div>
                 <img src={b.qr} alt={`bet cert ${b.player}`} />
               </div>
-            )
+            );
           })}
         </section>
       )}
@@ -295,14 +478,20 @@ export default function House() {
       {receipts.length > 0 && (
         <section className="bets">
           <h3>Bank Receipts</h3>
-          {receipts.map(r => {
-            const seatId = Number(r.player)
-            const label = players.find(p => p.id === seatId)?.name
+          {receipts.map((r) => {
+            const seatId = Number(r.player);
+            const label = players.find((p) => p.id === seatId)?.name;
             return (
               <div key={r.player}>
-                <div>{label ? `${label} (Seat ${seatId})` : `Seat ${seatId}`}</div>
+                <div>
+                  {label ? `${label} (Seat ${seatId})` : `Seat ${seatId}`}
+                </div>
                 <img src={r.qr} alt={`receipt ${r.player}`} />
-                {r.spendCode && <div>Spend code: <strong>{r.spendCode}</strong></div>}
+                {r.spendCode && (
+                  <div>
+                    Spend code: <strong>{r.spendCode}</strong>
+                  </div>
+                )}
                 <a
                   href={`data:application/json,${encodeURIComponent(JSON.stringify(r.receipt))}`}
                   download={`receipt-${r.player}.json`}
@@ -310,21 +499,25 @@ export default function House() {
                   Download
                 </a>
               </div>
-            )
+            );
           })}
         </section>
       )}
 
       <section className="bets">
         <h3>Overall Stats</h3>
-        <div><strong>Rounds Played:</strong> {stats.rounds}</div>
+        <div>
+          <strong>Rounds Played:</strong> {stats.rounds}
+        </div>
         <h4>Player Banks</h4>
         <ul>
-          {players.map(p => (
+          {players.map((p) => (
             <li key={p.id}>
               <span>{p.name}</span>
               <span> — </span>
-              <strong className={p.bank>=0?'pos':'neg'}>{fmtUSDSign(p.bank)}</strong>
+              <strong className={p.bank >= 0 ? 'pos' : 'neg'}>
+                {fmtUSDSign(p.bank)}
+              </strong>
             </li>
           ))}
         </ul>
@@ -332,15 +525,20 @@ export default function House() {
 
       <footer className="footer-bar">
         <div className="left">
-          {canInstall && <button className="install-btn" onClick={install}>Install</button>}
+          {canInstall && (
+            <button className="install-btn" onClick={install}>
+              Install
+            </button>
+          )}
           {installed && <span className="installed">Installed</span>}
         </div>
         <div className="center">© Kraken Consulting, LLC (Dev Team)</div>
         <div className="right">
-          <Link className="link-btn" to="/game">Game</Link>
+          <Link className="link-btn" to="/game">
+            Game
+          </Link>
         </div>
       </footer>
     </div>
-  )
+  );
 }
-

--- a/src/__tests__/JoinScannerFallback.test.tsx
+++ b/src/__tests__/JoinScannerFallback.test.tsx
@@ -1,72 +1,87 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi } from 'vitest'
-import { render, waitFor } from '@testing-library/react'
-import React from 'react'
-import { issueHouseCert } from '../certs/houseCert'
-import { createJoinChallenge } from '../join'
+import { describe, it, expect, vi } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import React from 'react';
+import { issueHouseCert } from '../certs/houseCert';
+import { createJoinChallenge } from '../join';
 
-function subtle() { return globalThis.crypto.subtle }
-async function genKeyPair() { return subtle().generateKey({ name: 'ECDSA', namedCurve: 'P-256' }, true, ['sign','verify']) }
+function subtle() {
+  return globalThis.crypto.subtle;
+}
+async function genKeyPair() {
+  return subtle().generateKey({ name: 'ECDSA', namedCurve: 'P-256' }, true, [
+    'sign',
+    'verify',
+  ]);
+}
 
-let mockData = ''
-vi.mock('jsqr', () => ({ default: vi.fn(() => ({ data: mockData })) }))
+let mockData = '';
+vi.mock('jsqr', () => ({ default: vi.fn(() => ({ data: mockData })) }));
 
-import JoinScanner from '../components/JoinScanner'
+import JoinScanner from '../components/JoinScanner';
 
 describe('JoinScanner fallback', () => {
   it('uses jsQR when BarcodeDetector is unavailable', async () => {
-    const root = await genKeyPair()
-    const house = await genKeyPair()
-    const player = await genKeyPair()
-    const secret = await subtle().generateKey({ name: 'HMAC', hash: 'SHA-256' }, true, ['sign'])
+    const root = await genKeyPair();
+    const house = await genKeyPair();
+    const player = await genKeyPair();
 
-    const houseCert = await issueHouseCert({
-      houseId: 'h1',
-      kid: 'k1',
-      housePubKey: await subtle().exportKey('jwk', house.publicKey),
-      notBefore: Date.now() - 1000,
-      notAfter: Date.now() + 60_000,
-      roles: ['host rounds'],
-    }, root.privateKey)
+    const houseCert = await issueHouseCert(
+      {
+        houseId: 'h1',
+        kid: 'k1',
+        housePubKey: await subtle().exportKey('jwk', house.publicKey),
+        notBefore: Date.now() - 1000,
+        notAfter: Date.now() + 60_000,
+        roles: ['host rounds'],
+      },
+      root.privateKey,
+    );
 
-    const challenge = await createJoinChallenge(houseCert, 'r1')
-    mockData = JSON.stringify(challenge)
+    const challenge = await createJoinChallenge(houseCert, 'r1');
+    mockData = JSON.stringify(challenge);
 
     Object.defineProperty(navigator, 'mediaDevices', {
-      value: { getUserMedia: vi.fn().mockResolvedValue({ getTracks: () => [] }) },
+      value: {
+        getUserMedia: vi.fn().mockResolvedValue({ getTracks: () => [] }),
+      },
       configurable: true,
-    })
+    });
 
-    HTMLVideoElement.prototype.play = vi.fn().mockResolvedValue(undefined)
+    HTMLVideoElement.prototype.play = vi.fn().mockResolvedValue(undefined);
 
     vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
-      cb(0)
-      return 0
-    })
+      cb(0);
+      return 0;
+    });
 
     HTMLCanvasElement.prototype.getContext = vi.fn().mockReturnValue({
       drawImage: vi.fn(),
-      getImageData: vi.fn().mockReturnValue({ data: new Uint8ClampedArray(), width: 0, height: 0 }),
-    })
+      getImageData: vi
+        .fn()
+        .mockReturnValue({
+          data: new Uint8ClampedArray(),
+          width: 0,
+          height: 0,
+        }),
+    });
 
-    const onResponse = vi.fn()
+    const onResponse = vi.fn();
 
     const { container } = render(
       <JoinScanner
-        playerId="p1"
-        playerKey={player.privateKey}
-        playerSecret={secret}
+        alias="p1"
+        playerKeys={player as CryptoKeyPair}
         rootKey={root.publicKey}
         onResponse={onResponse}
-      />
-    )
+      />,
+    );
 
-    const video = container.querySelector('video') as HTMLVideoElement
-    Object.defineProperty(video, 'videoWidth', { value: 100 })
-    Object.defineProperty(video, 'videoHeight', { value: 100 })
+    const video = container.querySelector('video') as HTMLVideoElement;
+    Object.defineProperty(video, 'videoWidth', { value: 100 });
+    Object.defineProperty(video, 'videoHeight', { value: 100 });
 
-    await waitFor(() => expect(onResponse).toHaveBeenCalled())
-    expect(onResponse.mock.calls[0][0].round).toBe('r1')
-  })
-})
-
+    await waitFor(() => expect(onResponse).toHaveBeenCalled());
+    expect(onResponse.mock.calls[0][0].round).toBe('r1');
+  });
+});

--- a/src/__tests__/join.test.ts
+++ b/src/__tests__/join.test.ts
@@ -1,53 +1,43 @@
-import { describe, it, expect } from 'vitest'
-import { createJoinChallenge, createJoinResponse, verifyJoinResponse } from '../join'
+import { describe, it, expect } from 'vitest';
+import {
+  createJoinChallenge,
+  createJoinResponse,
+  verifyJoinResponse,
+} from '../join';
 
-const subtle = globalThis.crypto.subtle
-
-async function genHmacKey() {
-  return subtle.generateKey({ name: 'HMAC', hash: 'SHA-256' }, true, ['sign', 'verify'])
-}
+const subtle = globalThis.crypto.subtle;
 
 async function genPlayerKeys() {
-  return subtle.generateKey({ name: 'ECDSA', namedCurve: 'P-256' }, true, ['sign', 'verify'])
+  return subtle.generateKey({ name: 'ECDSA', namedCurve: 'P-256' }, true, [
+    'sign',
+    'verify',
+  ]);
 }
 
 describe('verifyJoinResponse', () => {
   it('accepts a valid response', async () => {
-    const houseCert: any = { payload: {}, signature: '' }
-    const challenge = await createJoinChallenge(houseCert, 'r1')
-    const secret = await genHmacKey()
-    const playerKeys = await genPlayerKeys()
-    const response = await createJoinResponse('player1', challenge, secret, playerKeys.privateKey)
-    expect(await verifyJoinResponse(response, challenge, secret, playerKeys.publicKey)).toBe(true)
-  })
+    const houseCert: any = { payload: { houseId: 'h1' }, signature: '' };
+    const challenge = await createJoinChallenge(houseCert, 'r1');
+    const playerKeys = await genPlayerKeys();
+    const response = await createJoinResponse('player1', challenge, playerKeys);
+    expect(await verifyJoinResponse(response, challenge)).toBe(true);
+  });
 
   it('rejects when challenge fields mismatch', async () => {
-    const houseCert: any = { payload: {}, signature: '' }
-    const challenge = await createJoinChallenge(houseCert, 'r1')
-    const secret = await genHmacKey()
-    const playerKeys = await genPlayerKeys()
-    const response = await createJoinResponse('player1', challenge, secret, playerKeys.privateKey)
-    const badChallenge = { ...challenge, nonce: challenge.nonce + 'x' }
-    expect(await verifyJoinResponse(response, badChallenge, secret, playerKeys.publicKey)).toBe(false)
-  })
-
-  it('rejects with invalid hmac', async () => {
-    const houseCert: any = { payload: {}, signature: '' }
-    const challenge = await createJoinChallenge(houseCert, 'r1')
-    const secret = await genHmacKey()
-    const wrongSecret = await genHmacKey()
-    const playerKeys = await genPlayerKeys()
-    const response = await createJoinResponse('player1', challenge, secret, playerKeys.privateKey)
-    expect(await verifyJoinResponse(response, challenge, wrongSecret, playerKeys.publicKey)).toBe(false)
-  })
+    const houseCert: any = { payload: { houseId: 'h1' }, signature: '' };
+    const challenge = await createJoinChallenge(houseCert, 'r1');
+    const playerKeys = await genPlayerKeys();
+    const response = await createJoinResponse('player1', challenge, playerKeys);
+    const badChallenge = { ...challenge, nonce: challenge.nonce + 'x' };
+    expect(await verifyJoinResponse(response, badChallenge)).toBe(false);
+  });
 
   it('rejects with invalid signature', async () => {
-    const houseCert: any = { payload: {}, signature: '' }
-    const challenge = await createJoinChallenge(houseCert, 'r1')
-    const secret = await genHmacKey()
-    const playerKeys = await genPlayerKeys()
-    const otherKeys = await genPlayerKeys()
-    const response = await createJoinResponse('player1', challenge, secret, playerKeys.privateKey)
-    expect(await verifyJoinResponse(response, challenge, secret, otherKeys.publicKey)).toBe(false)
-  })
-})
+    const houseCert: any = { payload: { houseId: 'h1' }, signature: '' };
+    const challenge = await createJoinChallenge(houseCert, 'r1');
+    const playerKeys = await genPlayerKeys();
+    const response = await createJoinResponse('player1', challenge, playerKeys);
+    const tampered = { ...response, sig: response.sig.slice(0, -1) + 'A' };
+    expect(await verifyJoinResponse(tampered, challenge)).toBe(false);
+  });
+});

--- a/src/hooks/useJoin.ts
+++ b/src/hooks/useJoin.ts
@@ -1,96 +1,118 @@
-import React from 'react'
-import { joinResponseToQR } from '../joinQR'
-import { pairingToQR } from '../pairingQR'
-import { houseCertRootPublicKeyJwk } from '../certs/authorizedHouseCertLedger'
-import { validateHouseCert } from '../certs/houseCert'
-import { generateJoinTotp } from '../utils/totp'
-import type { JoinResponse, JoinChallenge } from '../join'
+import React from 'react';
+import { joinResponseToQR } from '../joinQR';
+import { pairingToQR } from '../pairingQR';
+import { houseCertRootPublicKeyJwk } from '../certs/authorizedHouseCertLedger';
+import { validateHouseCert } from '../certs/houseCert';
+import { generateJoinTotp } from '../utils/totp';
+import type { JoinResponse, JoinChallenge } from '../join';
 
-export function useJoin(){
+export function useJoin() {
   const [playerId, setPlayerId] = React.useState<string>(() => {
-    try { return localStorage.getItem('roll_et_player_id') || 'Player' } catch { return 'Player' }
-  })
-  React.useEffect(() => { try { localStorage.setItem('roll_et_player_id', playerId) } catch {} }, [playerId])
+    try {
+      return localStorage.getItem('roll_et_player_id') || 'Player';
+    } catch {
+      return 'Player';
+    }
+  });
+  React.useEffect(() => {
+    try {
+      localStorage.setItem('roll_et_player_id', playerId);
+    } catch {}
+  }, [playerId]);
 
-  const [joining, setJoining] = React.useState(false)
-  const [joinQR, setJoinQR] = React.useState<string | null>(null)
-  const [joinTotp, setJoinTotp] = React.useState<string | null>(null)
-  const [pairQR, setPairQR] = React.useState<string | null>(null)
-  const [housePublicKey, setHousePublicKey] = React.useState<CryptoKey | null>(null)
-  const [playerKeys, setPlayerKeys] = React.useState<CryptoKeyPair | null>(null)
-  const [playerSecret, setPlayerSecret] = React.useState<CryptoKey | null>(null)
-  const [rootKey, setRootKey] = React.useState<CryptoKey | null>(null)
+  const [joining, setJoining] = React.useState(false);
+  const [joinQR, setJoinQR] = React.useState<string | null>(null);
+  const [joinTotp, setJoinTotp] = React.useState<string | null>(null);
+  const [pairQR, setPairQR] = React.useState<string | null>(null);
+  const [housePublicKey, setHousePublicKey] = React.useState<CryptoKey | null>(
+    null,
+  );
+  const [playerKeys, setPlayerKeys] = React.useState<CryptoKeyPair | null>(
+    null,
+  );
+  const [playerSecret, setPlayerSecret] = React.useState<CryptoKey | null>(
+    null,
+  );
+  const [rootKey, setRootKey] = React.useState<CryptoKey | null>(null);
 
   React.useEffect(() => {
-    ;(async () => {
+    (async () => {
       const pkeys = await crypto.subtle.generateKey(
         { name: 'ECDSA', namedCurve: 'P-256' },
         true,
-        ['sign', 'verify']
-      )
+        ['sign', 'verify'],
+      );
       const secret = await crypto.subtle.generateKey(
         { name: 'HMAC', hash: 'SHA-256' },
         true,
-        ['sign']
-      )
-      setPlayerKeys(pkeys as CryptoKeyPair)
-      setPlayerSecret(secret)
+        ['sign'],
+      );
+      setPlayerKeys(pkeys as CryptoKeyPair);
+      setPlayerSecret(secret);
       const rk = await crypto.subtle.importKey(
         'jwk',
         houseCertRootPublicKeyJwk,
         { name: 'ECDSA', namedCurve: 'P-256' },
         true,
-        ['verify']
-      )
-      setRootKey(rk)
-    })()
-  }, [])
+        ['verify'],
+      );
+      setRootKey(rk);
+    })();
+  }, []);
 
   const joinScannerProps = React.useMemo(() => {
-    if (!playerKeys || !playerSecret || !rootKey) return null
+    if (!playerKeys || !rootKey) return null;
     return {
-      playerId: playerId || 'Player',
-      playerKey: playerKeys.privateKey,
-      playerSecret,
+      alias: playerId || 'Player',
+      playerKeys,
       rootKey,
       onResponse: async (resp: JoinResponse) => {
-        const img = await joinResponseToQR(resp)
-        setJoinQR(img)
-        setJoining(false)
+        const img = await joinResponseToQR(resp);
+        setJoinQR(img);
+        setJoining(false);
       },
       onResponseEx: async (resp: JoinResponse, challenge: JoinChallenge) => {
-        if (!playerSecret || !rootKey) return
-        const valid = await validateHouseCert(challenge.houseCert, rootKey)
-        if (!valid) return
+        if (!playerSecret || !rootKey) return;
+        const valid = await validateHouseCert(challenge.houseCert, rootKey);
+        if (!valid) return;
         const key = await crypto.subtle.importKey(
           'jwk',
           challenge.houseCert.payload.housePubKey,
           { name: 'ECDSA', namedCurve: 'P-256' },
           true,
-          ['verify']
-        )
-        setHousePublicKey(key)
-        const raw = await crypto.subtle.exportKey('raw', playerSecret)
-        const code = await generateJoinTotp(new Uint8Array(raw), resp.round, resp.nonce, challenge.nbf, 60_000)
-        setJoinTotp(code)
-      }
-    }
-  }, [playerId, playerKeys, playerSecret, rootKey])
+          ['verify'],
+        );
+        setHousePublicKey(key);
+        const raw = await crypto.subtle.exportKey('raw', playerSecret);
+        const code = await generateJoinTotp(
+          new Uint8Array(raw),
+          resp.round,
+          resp.nonce,
+          challenge.nbf,
+          60_000,
+        );
+        setJoinTotp(code);
+      },
+    };
+  }, [playerId, playerKeys, playerSecret, rootKey]);
 
   const showPairingCode = React.useCallback(async () => {
-    if (!playerSecret) return
-    const raw = await crypto.subtle.exportKey('raw', playerSecret)
-    const qr = await pairingToQR(playerId || 'Player', new Uint8Array(raw))
-    setPairQR(qr)
-  }, [playerSecret, playerId])
+    if (!playerSecret) return;
+    const raw = await crypto.subtle.exportKey('raw', playerSecret);
+    const qr = await pairingToQR(playerId || 'Player', new Uint8Array(raw));
+    setPairQR(qr);
+  }, [playerSecret, playerId]);
 
   return {
-    playerId, setPlayerId,
-    joining, setJoining,
-    joinQR, joinTotp,
-    pairQR, showPairingCode,
+    playerId,
+    setPlayerId,
+    joining,
+    setJoining,
+    joinQR,
+    joinTotp,
+    pairQR,
+    showPairingCode,
     joinScannerProps,
     housePublicKey,
-  }
+  };
 }
-

--- a/src/join.ts
+++ b/src/join.ts
@@ -1,87 +1,148 @@
-import { HouseCert, validateHouseCert } from './certs/houseCert'
-import QRCode from 'qrcode'
-import { bytesToBase64Url, base64UrlToBytes } from './utils/base64'
+import { HouseCert, validateHouseCert } from './certs/houseCert';
+import QRCode from 'qrcode';
+import { bytesToBase64Url, base64UrlToBytes } from './utils/base64';
 
-const subtle = globalThis.crypto.subtle
-const encoder = new TextEncoder()
+const subtle = globalThis.crypto.subtle;
+const encoder = new TextEncoder();
 
 export interface JoinChallenge {
-  type: 'join-challenge'
-  houseCert: HouseCert
-  round: string
-  nonce: string
-  nbf: number
-  exp: number
+  type: 'join-challenge';
+  houseCert: HouseCert;
+  round: string;
+  nonce: string;
+  nbf: number;
+  exp: number;
 }
 
-export async function createJoinChallenge(houseCert: HouseCert, round: string, ttlMs: number = 15000): Promise<JoinChallenge> {
-  const nonceArr = new Uint8Array(16)
-  globalThis.crypto.getRandomValues(nonceArr)
-  const nonce = bytesToBase64Url(nonceArr)
-  const now = Date.now()
-  return { type: 'join-challenge', houseCert, round, nonce, nbf: now, exp: now + ttlMs }
+export async function createJoinChallenge(
+  houseCert: HouseCert,
+  round: string,
+  ttlMs: number = 15000,
+): Promise<JoinChallenge> {
+  const nonceArr = new Uint8Array(16);
+  globalThis.crypto.getRandomValues(nonceArr);
+  const nonce = bytesToBase64Url(nonceArr);
+  const now = Date.now();
+  return {
+    type: 'join-challenge',
+    houseCert,
+    round,
+    nonce,
+    nbf: now,
+    exp: now + ttlMs,
+  };
 }
 
-export async function joinChallengeToQR(challenge: JoinChallenge): Promise<string> {
-  return QRCode.toDataURL(JSON.stringify(challenge))
+export async function joinChallengeToQR(
+  challenge: JoinChallenge,
+): Promise<string> {
+  return QRCode.toDataURL(JSON.stringify(challenge));
 }
 
 export function parseJoinChallenge(str: string): JoinChallenge {
-  return JSON.parse(str) as JoinChallenge
+  return JSON.parse(str) as JoinChallenge;
 }
 
-export async function validateJoinChallenge(challenge: JoinChallenge, rootKey: CryptoKey, now: number = Date.now()): Promise<boolean> {
-  if (now < challenge.nbf || now > challenge.exp) return false
-  return validateHouseCert(challenge.houseCert, rootKey, now)
+export async function validateJoinChallenge(
+  challenge: JoinChallenge,
+  rootKey: CryptoKey,
+  now: number = Date.now(),
+): Promise<boolean> {
+  if (now < challenge.nbf || now > challenge.exp) return false;
+  return validateHouseCert(challenge.houseCert, rootKey, now);
 }
 
-export interface JoinResponse {
-  player: string
-  round: string
-  nonce: string
-  hmac: string
-  bankRef?: string
-  sig: string
+export interface JoinResponsePayload {
+  playerUid: string;
+  playerPubKey: JsonWebKey;
+  round: string;
+  seat: number;
+  nonce: string;
+  bankRef?: string;
+}
+
+export interface JoinResponse extends JoinResponsePayload {
+  alias?: string;
+  sig: string;
+}
+
+async function derivePlayerUid(
+  pubKey: CryptoKey,
+  houseId: string,
+): Promise<string> {
+  const raw = new Uint8Array(await subtle.exportKey('raw', pubKey));
+  const house = encoder.encode(houseId);
+  const data = new Uint8Array(raw.length + house.length);
+  data.set(raw, 0);
+  data.set(house, raw.length);
+  const hash = await subtle.digest('SHA-256', data);
+  return bytesToBase64Url(new Uint8Array(hash));
 }
 
 export async function createJoinResponse(
-  playerId: string,
+  alias: string,
   challenge: JoinChallenge,
-  secret: CryptoKey,
-  playerKey: CryptoKey,
-  bankRef?: string
+  keys: CryptoKeyPair,
+  seat: number = 0,
+  bankRef?: string,
 ): Promise<JoinResponse> {
-  const data = encoder.encode(`${playerId}|${challenge.round}|${challenge.nonce}`)
-  const hmacBuf = await subtle.sign('HMAC', secret, data)
-  const hmac = bytesToBase64Url(new Uint8Array(hmacBuf))
-  const payload = { player: playerId, round: challenge.round, nonce: challenge.nonce, hmac, bankRef }
-  const sigBuf = await subtle.sign({ name: 'ECDSA', hash: 'SHA-256' }, playerKey, encoder.encode(JSON.stringify(payload)))
-  const sig = bytesToBase64Url(new Uint8Array(sigBuf))
-  return { ...payload, sig }
+  const playerPubKey = (await subtle.exportKey(
+    'jwk',
+    keys.publicKey,
+  )) as JsonWebKey;
+  const playerUid = await derivePlayerUid(
+    keys.publicKey,
+    challenge.houseCert.payload.houseId,
+  );
+  const payload: JoinResponsePayload = {
+    playerUid,
+    playerPubKey,
+    round: challenge.round,
+    seat,
+    nonce: challenge.nonce,
+    bankRef,
+  };
+  const sigBuf = await subtle.sign(
+    { name: 'ECDSA', hash: 'SHA-256' },
+    keys.privateKey,
+    encoder.encode(JSON.stringify(payload)),
+  );
+  const sig = bytesToBase64Url(new Uint8Array(sigBuf));
+  return { ...payload, alias, sig };
 }
 
 export async function verifyJoinResponse(
   response: JoinResponse,
   challenge: JoinChallenge,
-  secret: CryptoKey,
-  playerKey: CryptoKey
 ): Promise<boolean> {
-  if (response.round !== challenge.round) return false
-  if (response.nonce !== challenge.nonce) return false
-
-  const data = encoder.encode(`${response.player}|${challenge.round}|${challenge.nonce}`)
-  const hmacBytes = base64UrlToBytes(response.hmac) as Uint8Array<ArrayBuffer>
-  const hmacOk = await subtle.verify('HMAC', secret, hmacBytes, data)
-  if (!hmacOk) return false
-
-  const payload = {
-    player: response.player,
+  if (response.round !== challenge.round) return false;
+  if (response.nonce !== challenge.nonce) return false;
+  const playerKey = await subtle.importKey(
+    'jwk',
+    response.playerPubKey,
+    { name: 'ECDSA', namedCurve: 'P-256' },
+    true,
+    ['verify'],
+  );
+  const expectedUid = await derivePlayerUid(
+    playerKey,
+    challenge.houseCert.payload.houseId,
+  );
+  if (expectedUid !== response.playerUid) return false;
+  const payload: JoinResponsePayload = {
+    playerUid: response.playerUid,
+    playerPubKey: response.playerPubKey,
     round: response.round,
+    seat: response.seat,
     nonce: response.nonce,
-    hmac: response.hmac,
-    bankRef: response.bankRef
-  }
-  const sigBytes = base64UrlToBytes(response.sig) as Uint8Array<ArrayBuffer>
-  const payloadData = encoder.encode(JSON.stringify(payload))
-  return subtle.verify({ name: 'ECDSA', hash: 'SHA-256' }, playerKey, sigBytes, payloadData)
+    bankRef: response.bankRef,
+  };
+  const sigBytes = base64UrlToBytes(response.sig) as Uint8Array<ArrayBuffer>;
+  const payloadData = encoder.encode(JSON.stringify(payload));
+  return subtle.verify(
+    { name: 'ECDSA', hash: 'SHA-256' },
+    playerKey,
+    sigBytes,
+    payloadData,
+  );
 }


### PR DESCRIPTION
## Summary
- align join response with documentation by deriving player UID from key and house ID
- update join scanning flow to use keypair-based responses and verification
- adjust hooks, house flow, and tests for new join protocol

## Testing
- `npm run build`
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bc6e9ee8a48322a80b15a5144728fa