### PR TITLE
fix(join): harden signature verification

### DIFF
--- a/src/__tests__/join.test.ts
+++ b/src/__tests__/join.test.ts
@@ -4,6 +4,7 @@ import {
   createJoinResponse,
   verifyJoinResponse,
 } from '../join';
+import { base64UrlToBytes, bytesToBase64Url } from '../utils/base64';
 
 const subtle = globalThis.crypto.subtle;
 
@@ -37,7 +38,10 @@ describe('verifyJoinResponse', () => {
     const challenge = await createJoinChallenge(houseCert, 'r1');
     const playerKeys = await genPlayerKeys();
     const response = await createJoinResponse('player1', challenge, playerKeys);
-    const tampered = { ...response, sig: response.sig.slice(0, -1) + 'A' };
+    const bytes = base64UrlToBytes(response.sig);
+    bytes[0] ^= 0xff; // flip first byte
+    const tamperedSig = bytesToBase64Url(bytes);
+    const tampered = { ...response, sig: tamperedSig };
     expect(await verifyJoinResponse(tampered, challenge)).toBe(false);
   });
 });

--- a/src/utils/base64.ts
+++ b/src/utils/base64.ts
@@ -1,42 +1,50 @@
 function base64FromBytes(bytes: Uint8Array): string {
   if (typeof btoa === 'function') {
-    let binary = ''
-    for (const b of bytes) binary += String.fromCharCode(b)
-    return btoa(binary)
+    let binary = '';
+    for (const b of bytes) binary += String.fromCharCode(b);
+    return btoa(binary);
   }
-  return Buffer.from(bytes).toString('base64')
+  return Buffer.from(bytes).toString('base64');
 }
 
 function bytesFromBase64(base64: string): Uint8Array {
   if (typeof atob === 'function') {
-    const binary = atob(base64)
-    const bytes = new Uint8Array(binary.length)
-    for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i)
-    return bytes
+    const binary = atob(base64);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+    return bytes;
   }
-  return Uint8Array.from(Buffer.from(base64, 'base64'))
+  return Uint8Array.from(Buffer.from(base64, 'base64'));
 }
 
 export function bytesToBase64Url(bytes: Uint8Array): string {
-  return base64FromBytes(bytes).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '')
+  return base64FromBytes(bytes)
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/g, '');
 }
 
-export function base64UrlToBytes(base64url: string): Uint8Array {
-  const base64 = base64url.replace(/-/g, '+').replace(/_/g, '/')
-  const padLength = (4 - (base64.length % 4)) % 4
-  const padded = base64 + '='.repeat(padLength)
+export function base64UrlToBytes(base64url: string): Uint8Array<ArrayBuffer> {
+  const base64 = base64url.replace(/-/g, '+').replace(/_/g, '/');
+  // Ensure input contains only valid base64 characters. Buffer.from will
+  // otherwise ignore invalid characters and return an empty buffer.
+  if (!/^[A-Za-z0-9+/]*$/.test(base64)) {
+    throw new Error('Invalid base64url string');
+  }
+  const padLength = (4 - (base64.length % 4)) % 4;
+  const padded = base64 + '='.repeat(padLength);
 
   // Use atob in environments where it's available (browsers)
   if (typeof atob === 'function') {
-    const binary = atob(padded)
-    const bytes = new Uint8Array(binary.length)
+    const binary = atob(padded);
+    const bytes = new Uint8Array(binary.length);
     for (let i = 0; i < binary.length; i++) {
-      bytes[i] = binary.charCodeAt(i)
+      bytes[i] = binary.charCodeAt(i);
     }
-    return bytes
+    return bytes;
   }
 
   // Fall back to Buffer decoding when atob is unavailable (Node.js)
-  const buffer = Buffer.from(padded, 'base64')
-  return new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength)
+  const buffer = Buffer.from(padded, 'base64');
+  return new Uint8Array(buffer.buffer, buffer.byteOffset, buffer.byteLength);
 }


### PR DESCRIPTION
## Summary
- guard against malformed base64 inputs
- return false on join response verification errors
- ensure tampered signature test flips actual bytes

## Testing
- `npm run build`
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bc7435fd048322a412bafb8898654c