### PR TITLE
fix(certs): align bet certificate with contract

### DIFF
--- a/docs/ledger_sync_contract.md
+++ b/docs/ledger_sync_contract.md
@@ -60,7 +60,7 @@ Event types and their payload fields:
 - **`join_challenge_issued`** `{ round, nonce, nbf, exp }` — QR challenge parameters.
 - **`admission`** `{ seat, player?, name?, round?, method? }` — seat assignment with optional identifiers or join method.
 - **`round_locked`** `{ seatCount, maxSeats, players: [{ id, stake }] }` — round start snapshot.
-- **`bet_cert_issued`** `{ player, certId, betHash, exp }` — issued Bet Certificate details.
+- **`bet_cert_issued`** `{ seat, playerUidThumbprint, certId, betHash, exp }` — issued Bet Certificate details.
 - **`round_settled`** `{ roll, deltas }` — winning roll and per-seat credit changes.
 - **`receipt_issued`** `{ playerUidThumbprint, amount, receiptId }` — BANK receipt issuance.
 - **`receipt_spent`** `{ receiptId, playerUidThumbprint, amount, kind, method? }` — receipt redemption record.

--- a/src/__tests__/BetCertScanner.test.tsx
+++ b/src/__tests__/BetCertScanner.test.tsx
@@ -14,14 +14,19 @@ vi.mock('jsqr', () => ({ default: vi.fn(() => ({ data: mockData })) }))
 describe('BetCertScanner', () => {
   it('accepts a valid cert', async () => {
     const house = await genKeyPair()
-    const cert = await generateBetCert({
-      certId: 'c1',
-      player: 'p1',
-      round: 'r1',
-      betHash: 'h1',
-      nbf: Date.now() - 1000,
-      exp: Date.now() + 60000,
-    }, (house as CryptoKeyPair).privateKey)
+    const cert = await generateBetCert(
+      {
+        houseId: 'h1',
+        roundId: 'r1',
+        seat: 1,
+        playerUidThumbprint: 'p1',
+        certId: 'c1',
+        betHash: 'h1',
+        issuedAt: Date.now() - 1000,
+        exp: Date.now() + 60000,
+      },
+      (house as CryptoKeyPair).privateKey,
+    )
     mockData = JSON.stringify(cert)
 
     Object.defineProperty(navigator, 'mediaDevices', {
@@ -49,14 +54,19 @@ describe('BetCertScanner', () => {
   it('rejects an invalid cert', async () => {
     const goodHouse = await genKeyPair()
     const badHouse = await genKeyPair()
-    const cert = await generateBetCert({
-      certId: 'c1',
-      player: 'p1',
-      round: 'r1',
-      betHash: 'h1',
-      nbf: Date.now() - 1000,
-      exp: Date.now() + 60000,
-    }, (goodHouse as CryptoKeyPair).privateKey)
+    const cert = await generateBetCert(
+      {
+        houseId: 'h1',
+        roundId: 'r1',
+        seat: 1,
+        playerUidThumbprint: 'p1',
+        certId: 'c1',
+        betHash: 'h1',
+        issuedAt: Date.now() - 1000,
+        exp: Date.now() + 60000,
+      },
+      (goodHouse as CryptoKeyPair).privateKey,
+    )
     mockData = JSON.stringify(cert)
 
     Object.defineProperty(navigator, 'mediaDevices', {

--- a/src/__tests__/cert-encoding.test.ts
+++ b/src/__tests__/cert-encoding.test.ts
@@ -38,12 +38,14 @@ describe('certificate signature encoding utilities', () => {
     const house = await genKeyPair()
     const payload = {
       type: 'bet-cert' as const,
+      houseId: 'house-1',
+      roundId: 'r1',
+      seat: 1,
+      playerUidThumbprint: 'p1',
       certId: 'bet1',
-      player: 'p1',
-      round: 'r1',
+      issuedAt: Date.now() - 1000,
+      exp: Date.now() + 60_000,
       betHash: 'hash',
-      nbf: Date.now() - 1000,
-      exp: Date.now() + 60_000
     }
     const data = encoder.encode(JSON.stringify(payload))
     const sigBuf = await subtle().sign({ name: 'ECDSA', hash: 'SHA-256' }, house.privateKey, data)

--- a/src/__tests__/certs.test.ts
+++ b/src/__tests__/certs.test.ts
@@ -26,14 +26,19 @@ describe('certificate flows', () => {
     const cert = await issueHouseCert(payload, root.privateKey)
     expect(await validateHouseCert(cert, root.publicKey)).toBe(true)
 
-    const betCert = await generateBetCert({
-      certId: 'abc',
-      player: 'p1',
-      round: 'r1',
-      betHash: 'hash',
-      nbf: Date.now() - 1000,
-      exp: Date.now() + 60_000
-    }, houseKeys.privateKey)
+    const betCert = await generateBetCert(
+      {
+        houseId: 'house-1',
+        roundId: 'r1',
+        seat: 1,
+        playerUidThumbprint: 'p1',
+        certId: 'abc',
+        betHash: 'hash',
+        issuedAt: Date.now() - 1000,
+        exp: Date.now() + 60_000,
+      },
+      houseKeys.privateKey,
+    )
     expect(await verifyBetCert(betCert, houseKeys.publicKey)).toBe(true)
 
       const receipt = await issueBankReceipt(

--- a/src/__tests__/qr.test.ts
+++ b/src/__tests__/qr.test.ts
@@ -29,14 +29,19 @@ describe('QR flows', () => {
     const scanned = parseJoinChallenge(JSON.stringify(challenge))
     expect(await validateJoinChallenge(scanned, root.publicKey)).toBe(true)
 
-    const betCert = await generateBetCert({
-      certId: 'c1',
-      player: 'p1',
-      round: 'r1',
-      betHash: 'hash',
-      nbf: Date.now() - 1000,
-      exp: Date.now() + 60_000
-    }, house.privateKey)
+    const betCert = await generateBetCert(
+      {
+        houseId: 'h1',
+        roundId: 'r1',
+        seat: 1,
+        playerUidThumbprint: 'p1',
+        certId: 'c1',
+        betHash: 'hash',
+        issuedAt: Date.now() - 1000,
+        exp: Date.now() + 60_000,
+      },
+      house.privateKey,
+    )
     const betQR = await betCertToQR(betCert)
     expect(betQR.startsWith('data:image/png;base64')).toBe(true)
     const parsedBet = parseBetCert(JSON.stringify(betCert))

--- a/src/__tests__/round.test.ts
+++ b/src/__tests__/round.test.ts
@@ -12,8 +12,8 @@ describe('round locking', () => {
       { id: 1, name: 'P1', bets: [{ id: 'b1', type: 'single', selection: [1], amount: 1 }], pool: 0, bank: 0 },
       { id: 2, name: 'P2', bets: [], pool: 0, bank: 0 }
     ]
-    const certs = await lockRound(players, house.privateKey, 'r1')
+    const certs = await lockRound(players, house.privateKey, 'r1', 'house-1')
     expect(certs).toHaveLength(2)
-    expect(certs[0].player).toBe('1')
+    expect(certs[0].seat).toBe(1)
   })
 })

--- a/src/round.ts
+++ b/src/round.ts
@@ -22,19 +22,29 @@ async function hashBets(bets: Bet[]): Promise<string> {
     .join('')
 }
 
-export async function lockRound(players: Player[], houseKey: CryptoKey, roundId: string): Promise<BetCert[]> {
+export async function lockRound(
+  players: Player[],
+  houseKey: CryptoKey,
+  roundId: string,
+  houseId: string,
+): Promise<BetCert[]> {
   const now = Date.now()
   const certs: BetCert[] = []
   for (const p of players) {
     const betHash = await hashBets(p.bets)
-    const cert = await generateBetCert({
-      certId: uuid(),
-      player: String(p.id),
-      round: roundId,
-      betHash,
-      nbf: now,
-      exp: now + 5 * 60 * 1000,
-    }, houseKey)
+    const cert = await generateBetCert(
+      {
+        certId: uuid(),
+        houseId,
+        roundId,
+        seat: p.id,
+        playerUidThumbprint: String(p.id),
+        betHash,
+        issuedAt: now,
+        exp: now + 5 * 60 * 1000,
+      },
+      houseKey,
+    )
     certs.push(cert)
   }
   return certs


### PR DESCRIPTION
## Summary
- expand bet certificate to include house and player bindings per contract
- issue bet certs with seat and thumbprint and log to ledger
- document updated bet_cert_issued fields

## Testing
- `npm run build`
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bc775016fc8322ac1e71a97877738e