### PR TITLE
feat(ledger): add entryId and checkpoint fields

### DIFF
--- a/src/__tests__/ledger.test.ts
+++ b/src/__tests__/ledger.test.ts
@@ -1,46 +1,65 @@
-import { describe, it, expect, beforeEach } from 'vitest'
-import { appendLedger, getLedger, getUnsyncedEntries, markSynced } from '../ledger/localLedger'
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  appendLedger,
+  getLedger,
+  getUnsyncedEntries,
+  markSynced,
+} from '../ledger/localLedger';
 
-const store: Record<string, string> = {}
+const store: Record<string, string> = {};
 const localStorageMock = {
   getItem(key: string) {
-    return Object.prototype.hasOwnProperty.call(store, key) ? store[key] : null
+    return Object.prototype.hasOwnProperty.call(store, key) ? store[key] : null;
   },
   setItem(key: string, value: string) {
-    store[key] = value
+    store[key] = value;
   },
   removeItem(key: string) {
-    delete store[key]
+    delete store[key];
   },
-}
-;(globalThis as any).localStorage = localStorageMock
+};
+(globalThis as any).localStorage = localStorageMock;
 
 describe('local ledger', () => {
   beforeEach(() => {
-    localStorage.removeItem('roll_et_ledger_v1')
-    localStorage.removeItem('roll_et_ledger_last_synced_seq')
-  })
+    localStorage.removeItem('roll_et_ledger_v1');
+    localStorage.removeItem('roll_et_ledger_last_synced_seq');
+  });
 
   it('appends with increasing seq and hash chain', async () => {
-    const a = await appendLedger('round_locked', 'r1', { players: [] })
-    const b = await appendLedger('round_settled', 'r1', { roll: 7 })
-    const all = getLedger()
-    expect(all.length).toBe(2)
-    expect(a.seq).toBe(1)
-    expect(b.seq).toBe(2)
-    expect(b.prevHash).toBe(a.hash)
-    expect(a.hash).toMatch(/^[0-9a-f]{64}$/)
-  })
+    const a = await appendLedger('round_locked', 'r1', { players: [] });
+    const b = await appendLedger('round_settled', 'r1', { roll: 7 });
+    const all = getLedger();
+    expect(all.length).toBe(2);
+    expect(a.seq).toBe(1);
+    expect(b.seq).toBe(2);
+    expect(b.prevHash).toBe(a.entryId);
+    expect(a.entryId).toMatch(/^[0-9a-f]{64}$/);
+    expect(typeof a.ts).toBe('number');
+  });
 
   it('tracks unsynced entries by seq', async () => {
-    await appendLedger('round_locked', 'r2', {})
-    await appendLedger('round_settled', 'r2', {})
-    let unsynced = getUnsyncedEntries()
-    expect(unsynced.length).toBe(2)
-    markSynced(1)
-    unsynced = getUnsyncedEntries()
-    expect(unsynced.length).toBe(1)
-    expect(unsynced[0].seq).toBe(2)
-  })
-})
+    await appendLedger('round_locked', 'r2', {});
+    await appendLedger('round_settled', 'r2', {});
+    let unsynced = getUnsyncedEntries();
+    expect(unsynced.length).toBe(2);
+    markSynced(1);
+    unsynced = getUnsyncedEntries();
+    expect(unsynced.length).toBe(1);
+    expect(unsynced[0].seq).toBe(2);
+  });
 
+  it('stores optional sig and merkleRoot', async () => {
+    const e = await appendLedger(
+      'round_locked',
+      'r1',
+      {},
+      {
+        sig: 'sig123',
+        merkleRoot: 'root456',
+      },
+    );
+    expect(e.sig).toBe('sig123');
+    expect(e.merkleRoot).toBe('root456');
+  });
+});

--- a/src/ledger/localLedger.ts
+++ b/src/ledger/localLedger.ts
@@ -1,4 +1,4 @@
-const encoder = new TextEncoder()
+const encoder = new TextEncoder();
 
 export type LedgerEventType =
   | 'round_locked'
@@ -7,86 +7,100 @@ export type LedgerEventType =
   | 'receipt_issued'
   | 'join_challenge_issued'
   | 'admission'
-  | 'receipt_spent'
+  | 'receipt_spent';
 
 export interface LedgerEntry<T = any> {
-  seq: number
-  prevHash: string | null
-  hash: string
-  time: number
-  roundId: string
-  type: LedgerEventType
-  payload: T
+  seq: number;
+  prevHash: string | null;
+  entryId: string;
+  ts: number;
+  roundId: string;
+  type: LedgerEventType;
+  payload: T;
+  sig?: string;
+  merkleRoot?: string;
 }
 
-const LEDGER_KEY = 'roll_et_ledger_v1'
-const LEDGER_SYNCED_KEY = 'roll_et_ledger_last_synced_seq'
+const LEDGER_KEY = 'roll_et_ledger_v1';
+const LEDGER_SYNCED_KEY = 'roll_et_ledger_last_synced_seq';
 
 function readLedger(): LedgerEntry[] {
   try {
-    const raw = localStorage.getItem(LEDGER_KEY)
-    return raw ? (JSON.parse(raw) as LedgerEntry[]) : []
+    const raw = localStorage.getItem(LEDGER_KEY);
+    return raw ? (JSON.parse(raw) as LedgerEntry[]) : [];
   } catch {
-    return []
+    return [];
   }
 }
 
 function writeLedger(entries: LedgerEntry[]): void {
   try {
-    localStorage.setItem(LEDGER_KEY, JSON.stringify(entries))
+    localStorage.setItem(LEDGER_KEY, JSON.stringify(entries));
   } catch {}
 }
 
 function readLastSyncedSeq(): number {
   try {
-    const raw = localStorage.getItem(LEDGER_SYNCED_KEY)
-    return raw ? Number(raw) || 0 : 0
+    const raw = localStorage.getItem(LEDGER_SYNCED_KEY);
+    return raw ? Number(raw) || 0 : 0;
   } catch {
-    return 0
+    return 0;
   }
 }
 
 function writeLastSyncedSeq(seq: number): void {
   try {
-    localStorage.setItem(LEDGER_SYNCED_KEY, String(seq))
+    localStorage.setItem(LEDGER_SYNCED_KEY, String(seq));
   } catch {}
 }
 
 async function sha256Hex(input: string): Promise<string> {
-  const buf = await crypto.subtle.digest('SHA-256', encoder.encode(input))
-  const bytes = new Uint8Array(buf)
-  return Array.from(bytes).map(b => b.toString(16).padStart(2, '0')).join('')
+  const buf = await crypto.subtle.digest('SHA-256', encoder.encode(input));
+  const bytes = new Uint8Array(buf);
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
 }
 
 export async function appendLedger<T = any>(
   type: LedgerEventType,
   roundId: string,
-  payload: T
+  payload: T,
+  opts: { sig?: string; merkleRoot?: string } = {},
 ): Promise<LedgerEntry<T>> {
-  const entries = readLedger()
-  const prev = entries[entries.length - 1]
-  const seq = (prev?.seq ?? 0) + 1
-  const time = Date.now()
-  const prevHash = prev?.hash ?? null
-  const toHash = `${prevHash ?? ''}|${seq}|${time}|${roundId}|${type}|${JSON.stringify(payload)}`
-  const hash = await sha256Hex(toHash)
-  const entry: LedgerEntry<T> = { seq, prevHash, hash, time, roundId, type, payload }
-  entries.push(entry)
-  writeLedger(entries)
-  return entry
+  const entries = readLedger();
+  const prev = entries[entries.length - 1];
+  const seq = (prev?.seq ?? 0) + 1;
+  const ts = Date.now();
+  const prevHash = prev?.entryId ?? null;
+  const toHash = `${prevHash ?? ''}|${type}|${JSON.stringify(payload)}|${ts}`;
+  const entryId = await sha256Hex(toHash);
+  const entry: LedgerEntry<T> = {
+    seq,
+    prevHash,
+    entryId,
+    ts,
+    roundId,
+    type,
+    payload,
+    ...(opts.sig && { sig: opts.sig }),
+    ...(opts.merkleRoot && { merkleRoot: opts.merkleRoot }),
+  };
+  entries.push(entry);
+  writeLedger(entries);
+  return entry;
 }
 
 export function getLedger(): LedgerEntry[] {
-  return readLedger()
+  return readLedger();
 }
 
 export function getUnsyncedEntries(): LedgerEntry[] {
-  const last = readLastSyncedSeq()
-  return readLedger().filter(e => e.seq > last)
+  const last = readLastSyncedSeq();
+  return readLedger().filter((e) => e.seq > last);
 }
 
 export function markSynced(uptoSeq: number): void {
-  const last = readLastSyncedSeq()
-  if (uptoSeq > last) writeLastSyncedSeq(uptoSeq)
+  const last = readLastSyncedSeq();
+  if (uptoSeq > last) writeLastSyncedSeq(uptoSeq);
 }
-


### PR DESCRIPTION
## Summary
- add entryId, ts, and optional sig/merkleRoot to ledger entries
- compute entryId from prevHash, type, payload, and timestamp
- test ledger checkpoint fields

## Testing
- `npm run build`
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bc7c0412288322b779114087818a97