### PR TITLE
feat(ledger): add checkpoint events and entry-id sync

### DIFF
--- a/src/House.tsx
+++ b/src/House.tsx
@@ -102,7 +102,8 @@ export default function House() {
     }
     setRoundState('locked');
     const roundId = String(stats.rounds + 1);
-    await appendLedger('round_locked', roundId, {
+    await appendLedger('round_locked', {
+      roundId,
       seatCount: players.length,
       maxSeats: MAX_SEATS,
       players: players.map((p) => ({
@@ -127,7 +128,8 @@ export default function House() {
       }, {}),
     );
     for (const c of certs) {
-      await appendLedger('bet_cert_issued', roundId, {
+      await appendLedger('bet_cert_issued', {
+        roundId,
         seat: c.seat,
         playerUidThumbprint: c.playerUidThumbprint,
         certId: c.certId,
@@ -163,7 +165,11 @@ export default function House() {
       return [...prev, np].sort((a, b) => a.id - b.id);
     });
     // Log admission to ledger for the upcoming round
-    await appendLedger('admission', String(stats.rounds + 1), { seat, name });
+    await appendLedger('admission', {
+      roundId: String(stats.rounds + 1),
+      seat,
+      name,
+    });
     setNewPlayerName('');
   };
 
@@ -236,17 +242,14 @@ export default function House() {
                     alert('Receipt already spent.');
                     return;
                   }
-                  await appendLedger(
-                    'receipt_spent',
-                    String(stats.rounds + 1),
-                    {
-                      receiptId: rec.receipt.receiptId,
-                      playerUidThumbprint: rec.receipt.playerUidThumbprint,
-                      amount: rec.receipt.amount,
-                      kind: rec.receipt.kind,
-                      method: 'code',
-                    },
-                  );
+                  await appendLedger('receipt_spent', {
+                    roundId: String(stats.rounds + 1),
+                    receiptId: rec.receipt.receiptId,
+                    playerUidThumbprint: rec.receipt.playerUidThumbprint,
+                    amount: rec.receipt.amount,
+                    kind: rec.receipt.kind,
+                    method: 'code',
+                  });
                   set.add(rec.receipt.receiptId);
                   localStorage.setItem(
                     spentKey,
@@ -318,7 +321,8 @@ export default function House() {
                         },
                       ].sort((a, b) => a.id - b.id),
                     );
-                    await appendLedger('admission', String(stats.rounds + 1), {
+                    await appendLedger('admission', {
+                      roundId: String(stats.rounds + 1),
                       seat,
                       player: matched!,
                       round: lastChallenge.round,
@@ -396,7 +400,8 @@ export default function House() {
                     },
                   ].sort((a, b) => a.id - b.id),
                 );
-                await appendLedger('admission', String(stats.rounds + 1), {
+                await appendLedger('admission', {
+                  roundId: String(stats.rounds + 1),
                   seat,
                   player: alias,
                   round: resp.round,
@@ -441,7 +446,8 @@ export default function House() {
                 setScanningSpend(false);
                 return;
               }
-              await appendLedger('receipt_spent', String(stats.rounds + 1), {
+              await appendLedger('receipt_spent', {
+                roundId: String(stats.rounds + 1),
                 receiptId: receipt.receiptId,
                 playerUidThumbprint: receipt.playerUidThumbprint,
                 amount: receipt.amount,

--- a/src/__tests__/ledger.test.ts
+++ b/src/__tests__/ledger.test.ts
@@ -23,37 +23,37 @@ const localStorageMock = {
 describe('local ledger', () => {
   beforeEach(() => {
     localStorage.removeItem('roll_et_ledger_v1');
-    localStorage.removeItem('roll_et_ledger_last_synced_seq');
+    localStorage.removeItem('roll_et_ledger_last_synced_entry_id');
   });
 
-  it('appends with increasing seq and hash chain', async () => {
-    const a = await appendLedger('round_locked', 'r1', { players: [] });
-    const b = await appendLedger('round_settled', 'r1', { roll: 7 });
+  it('appends with hash chain', async () => {
+    const a = await appendLedger('round_locked', {
+      roundId: 'r1',
+      players: [],
+    });
+    const b = await appendLedger('round_settled', { roundId: 'r1', roll: 7 });
     const all = getLedger();
     expect(all.length).toBe(2);
-    expect(a.seq).toBe(1);
-    expect(b.seq).toBe(2);
     expect(b.prevHash).toBe(a.entryId);
     expect(a.entryId).toMatch(/^[0-9a-f]{64}$/);
     expect(typeof a.ts).toBe('number');
   });
 
-  it('tracks unsynced entries by seq', async () => {
-    await appendLedger('round_locked', 'r2', {});
-    await appendLedger('round_settled', 'r2', {});
+  it('tracks unsynced entries by entryId', async () => {
+    const first = await appendLedger('round_locked', { roundId: 'r2' });
+    const second = await appendLedger('round_settled', { roundId: 'r2' });
     let unsynced = getUnsyncedEntries();
     expect(unsynced.length).toBe(2);
-    markSynced(1);
+    markSynced(first.entryId);
     unsynced = getUnsyncedEntries();
     expect(unsynced.length).toBe(1);
-    expect(unsynced[0].seq).toBe(2);
+    expect(unsynced[0].entryId).toBe(second.entryId);
   });
 
   it('stores optional sig and merkleRoot', async () => {
     const e = await appendLedger(
       'round_locked',
-      'r1',
-      {},
+      { roundId: 'r1' },
       {
         sig: 'sig123',
         merkleRoot: 'root456',

--- a/src/hooks/useBetting.ts
+++ b/src/hooks/useBetting.ts
@@ -1,49 +1,64 @@
-import React from 'react'
-import { Bet, makeCornerFromAnchor, resolveRound } from '../game/engine'
-import { describeBet, potential } from '../utils/betHelpers'
-import { usePlayers, useRoundState, useStats, PER_ROUND_POOL, useHouse } from '../context/GameContext'
-import type { BetMode, Player } from '../types'
-import { clampInt } from '../utils'
-import { useBetActions } from './useBetActions'
-import { issueReceiptsForWinners } from '../receipts'
-import { appendLedger } from '../ledger/localLedger'
+import React from 'react';
+import { Bet, makeCornerFromAnchor, resolveRound } from '../game/engine';
+import { describeBet, potential } from '../utils/betHelpers';
+import {
+  usePlayers,
+  useRoundState,
+  useStats,
+  PER_ROUND_POOL,
+  useHouse,
+} from '../context/GameContext';
+import type { BetMode, Player } from '../types';
+import { clampInt } from '../utils';
+import { useBetActions } from './useBetActions';
+import { issueReceiptsForWinners } from '../receipts';
+import { appendLedger } from '../ledger/localLedger';
 
-export const MIN_BET = 1
+export const MIN_BET = 1;
 
 export function useBetting() {
-  const { players, setPlayers } = usePlayers()
-  const { roundState, setRoundState } = useRoundState()
-  const { stats, setStats } = useStats()
-    const { houseKey, setBetCerts, setReceipts } = useHouse()
+  const { players, setPlayers } = usePlayers();
+  const { roundState, setRoundState } = useRoundState();
+  const { stats, setStats } = useStats();
+  const { houseKey, setBetCerts, setReceipts } = useHouse();
 
-  const DEFAULT_BET = 1
+  const DEFAULT_BET = 1;
   const [amount, setAmount] = React.useState<number>(() => {
-    const saved = localStorage.getItem('bet')
-    const n = saved ? Number(saved) : DEFAULT_BET
-    return Number.isFinite(n) ? clampInt(n, MIN_BET, PER_ROUND_POOL) : DEFAULT_BET
-  })
-  React.useEffect(() => { localStorage.setItem('bet', String(amount)) }, [amount])
-
-  const [mode, setMode] = React.useState<BetMode>({ kind: 'single' })
-  const [enteredRoll, setEnteredRoll] = React.useState<number | ''>('')
-  const [history, setHistory] = React.useState<Array<{ roll: number, deltas: Record<number, number>, time: number }>>([])
-  const [winning, setWinning] = React.useState<number | null>(null)
-
-  const [activeId, setActiveId] = React.useState<number | null>(players[0]?.id ?? null)
+    const saved = localStorage.getItem('bet');
+    const n = saved ? Number(saved) : DEFAULT_BET;
+    return Number.isFinite(n)
+      ? clampInt(n, MIN_BET, PER_ROUND_POOL)
+      : DEFAULT_BET;
+  });
   React.useEffect(() => {
-    if (activeId != null && players.some(p => p.id === activeId)) return
-    if (players.length > 0) setActiveId(players[0].id)
-    else setActiveId(null)
-  }, [players])
+    localStorage.setItem('bet', String(amount));
+  }, [amount]);
 
-  const active = players.find(p => p.id === activeId) || players[0]
-  const maxForActive = active ? Math.max(MIN_BET, active.pool) : MIN_BET
+  const [mode, setMode] = React.useState<BetMode>({ kind: 'single' });
+  const [enteredRoll, setEnteredRoll] = React.useState<number | ''>('');
+  const [history, setHistory] = React.useState<
+    Array<{ roll: number; deltas: Record<number, number>; time: number }>
+  >([]);
+  const [winning, setWinning] = React.useState<number | null>(null);
+
+  const [activeId, setActiveId] = React.useState<number | null>(
+    players[0]?.id ?? null,
+  );
+  React.useEffect(() => {
+    if (activeId != null && players.some((p) => p.id === activeId)) return;
+    if (players.length > 0) setActiveId(players[0].id);
+    else setActiveId(null);
+  }, [players]);
+
+  const active = players.find((p) => p.id === activeId) || players[0];
+  const maxForActive = active ? Math.max(MIN_BET, active.pool) : MIN_BET;
 
   React.useEffect(() => {
-    setAmount(a => clampInt(a, MIN_BET, maxForActive))
-  }, [active?.pool])
+    setAmount((a) => clampInt(a, MIN_BET, maxForActive));
+  }, [active?.pool]);
 
-  const canPlace = (p: Player) => roundState === 'open' && amount >= MIN_BET && amount <= p.pool
+  const canPlace = (p: Player) =>
+    roundState === 'open' && amount >= MIN_BET && amount <= p.pool;
 
   const { addBetFor, undoLast, clearBets } = useBetActions({
     roundState,
@@ -51,134 +66,158 @@ export function useBetting() {
     mode,
     setMode,
     perRoundPool: PER_ROUND_POOL,
-  })
+  });
 
   const covered = React.useMemo(() => {
-    const s = new Set<number>()
+    const s = new Set<number>();
     for (const p of players) {
       for (const b of p.bets) {
         switch (b.type) {
           case 'single':
           case 'split':
           case 'corner':
-            b.selection.forEach(n => s.add(n)); break
+            b.selection.forEach((n) => s.add(n));
+            break;
           case 'even':
-            for (let n = 2; n <= 20; n += 2) s.add(n); break
+            for (let n = 2; n <= 20; n += 2) s.add(n);
+            break;
           case 'odd':
-            for (let n = 1; n <= 19; n += 2) s.add(n); break
+            for (let n = 1; n <= 19; n += 2) s.add(n);
+            break;
           case 'high':
-            for (let n = 11; n <= 20; n++) s.add(n); break
+            for (let n = 11; n <= 20; n++) s.add(n);
+            break;
           case 'low':
-            for (let n = 1; n <= 10; n++) s.add(n); break
+            for (let n = 1; n <= 10; n++) s.add(n);
+            break;
         }
       }
     }
-    return s
-  }, [players])
+    return s;
+  }, [players]);
 
   const onCellClick = (n: number) => {
-    if (roundState !== 'open') return
-    const p = active
-    if (!p || !canPlace(p)) return
+    if (roundState !== 'open') return;
+    const p = active;
+    if (!p || !canPlace(p)) return;
     switch (mode.kind) {
       case 'single':
-        addBetFor(p.id, { type: 'single', selection: [n], amount })
-        break
+        addBetFor(p.id, { type: 'single', selection: [n], amount });
+        break;
       case 'split': {
-        const first = (mode as any).first as number | undefined
+        const first = (mode as any).first as number | undefined;
         if (first == null) {
-          setMode({ kind: 'split', first: n })
+          setMode({ kind: 'split', first: n });
         } else {
-          if (!isAdjacent(first, n)) { setMode({ kind: 'split' }); return }
-          const pair = [first, n].sort((a, b) => a - b)
-          addBetFor(p.id, { type: 'split', selection: pair, amount })
-          setMode({ kind: 'split' })
+          if (!isAdjacent(first, n)) {
+            setMode({ kind: 'split' });
+            return;
+          }
+          const pair = [first, n].sort((a, b) => a - b);
+          addBetFor(p.id, { type: 'split', selection: pair, amount });
+          setMode({ kind: 'split' });
         }
-        break
+        break;
       }
       case 'corner': {
-        const q = makeCornerFromAnchor(n)
-        if (q) addBetFor(p.id, { type: 'corner', selection: q, amount })
-        break
+        const q = makeCornerFromAnchor(n);
+        if (q) addBetFor(p.id, { type: 'corner', selection: q, amount });
+        break;
       }
       case 'high':
-        addBetFor(p.id, { type: 'high', selection: [], amount })
-        break
+        addBetFor(p.id, { type: 'high', selection: [], amount });
+        break;
       case 'low':
-        addBetFor(p.id, { type: 'low', selection: [], amount })
-        break
+        addBetFor(p.id, { type: 'low', selection: [], amount });
+        break;
       case 'even':
-        addBetFor(p.id, { type: 'even', selection: [], amount })
-        break
+        addBetFor(p.id, { type: 'even', selection: [], amount });
+        break;
       case 'odd':
-        addBetFor(p.id, { type: 'odd', selection: [], amount })
-        break
+        addBetFor(p.id, { type: 'odd', selection: [], amount });
+        break;
     }
-  }
+  };
 
-  const lockRound = () => { setRoundState('locked') }
+  const lockRound = () => {
+    setRoundState('locked');
+  };
 
   const settleRound = async () => {
-    if (roundState !== 'locked') return
-    const roll = Number(enteredRoll)
-    if (!Number.isInteger(roll) || roll < 1 || roll > 20) return
+    if (roundState !== 'locked') return;
+    const roll = Number(enteredRoll);
+    if (!Number.isInteger(roll) || roll < 1 || roll > 20) return;
 
-    const deltas: Record<number, number> = {}
-    const nextPlayers = players.map(p => {
-      const stake = p.bets.reduce((a, b) => a + b.amount, 0)
-      const win = resolveRound(roll, p.bets)
-      const delta = win - stake
-      deltas[p.id] = delta
-      return { ...p, bank: p.bank + delta }
-    })
+    const deltas: Record<number, number> = {};
+    const nextPlayers = players.map((p) => {
+      const stake = p.bets.reduce((a, b) => a + b.amount, 0);
+      const win = resolveRound(roll, p.bets);
+      const delta = win - stake;
+      deltas[p.id] = delta;
+      return { ...p, bank: p.bank + delta };
+    });
 
-    setStats(prev => {
-      const hits = [...prev.hits]
-      hits[roll] = (hits[roll] || 0) + 1
-      const banks = { ...prev.banks }
-      nextPlayers.forEach(p => { banks[p.id] = p.bank })
-      return { rounds: prev.rounds + 1, hits, banks }
-    })
+    setStats((prev) => {
+      const hits = [...prev.hits];
+      hits[roll] = (hits[roll] || 0) + 1;
+      const banks = { ...prev.banks };
+      nextPlayers.forEach((p) => {
+        banks[p.id] = p.bank;
+      });
+      return { rounds: prev.rounds + 1, hits, banks };
+    });
 
-      if (houseKey) {
-        const winners = players
-          .filter(p => deltas[p.id] > 0)
-          .map(p => ({
-            player: p.id,
-            playerUidThumbprint: String(p.id),
-            amount: deltas[p.id],
-            kind: 'REBUY' as const,
-          }))
-        const roundId = String(stats.rounds + 1)
-        const houseId = 'house-1'
-        const recs = await issueReceiptsForWinners(winners, roundId, houseId, houseKey.privateKey)
-        setReceipts(recs)
-        for (let i = 0; i < winners.length; i++) {
-          const w = winners[i]
-          const rec = (recs[i] && recs[i].receipt) ? recs[i] : undefined
-          await appendLedger('receipt_issued', roundId, {
-            playerUidThumbprint: w.playerUidThumbprint,
-            amount: w.amount,
-            receiptId: rec?.receipt.receiptId,
-          })
-        }
+    if (houseKey) {
+      const winners = players
+        .filter((p) => deltas[p.id] > 0)
+        .map((p) => ({
+          player: p.id,
+          playerUidThumbprint: String(p.id),
+          amount: deltas[p.id],
+          kind: 'REBUY' as const,
+        }));
+      const roundId = String(stats.rounds + 1);
+      const houseId = 'house-1';
+      const recs = await issueReceiptsForWinners(
+        winners,
+        roundId,
+        houseId,
+        houseKey.privateKey,
+      );
+      setReceipts(recs);
+      for (let i = 0; i < winners.length; i++) {
+        const w = winners[i];
+        const rec = recs[i] && recs[i].receipt ? recs[i] : undefined;
+        await appendLedger('receipt_issued', {
+          roundId,
+          playerUidThumbprint: w.playerUidThumbprint,
+          amount: w.amount,
+          receiptId: rec?.receipt.receiptId,
+        });
       }
+    }
 
-    setPlayers(nextPlayers)
-    await appendLedger('round_settled', String(stats.rounds + 1), { roll, deltas })
-    setHistory(h => [{ roll, deltas, time: Date.now() }, ...h].slice(0, 30))
-    setWinning(roll)
-    setRoundState('settled')
-  }
+    setPlayers(nextPlayers);
+    await appendLedger('round_settled', {
+      roundId: String(stats.rounds + 1),
+      roll,
+      deltas,
+    });
+    setHistory((h) => [{ roll, deltas, time: Date.now() }, ...h].slice(0, 30));
+    setWinning(roll);
+    setRoundState('settled');
+  };
 
   const newRound = () => {
-    setPlayers(prev => prev.map(p => ({ ...p, pool: PER_ROUND_POOL, bets: [] })))
-    setEnteredRoll('')
-    setWinning(null)
-    setRoundState('open')
-    setBetCerts({})
-    setReceipts([])
-  }
+    setPlayers((prev) =>
+      prev.map((p) => ({ ...p, pool: PER_ROUND_POOL, bets: [] })),
+    );
+    setEnteredRoll('');
+    setWinning(null);
+    setRoundState('open');
+    setBetCerts({});
+    setReceipts([]);
+  };
 
   return {
     players,
@@ -206,15 +245,17 @@ export function useBetting() {
     newRound,
     describeBet,
     potential,
-  }
+  };
 }
 
 function isAdjacent(a: number, b: number): boolean {
   const pos = (n: number) => {
-    const idx = n - 1
-    return { r: Math.floor(idx / 5), c: idx % 5 }
-  }
-  const A = pos(a), B = pos(b)
-  const dr = Math.abs(A.r - B.r), dc = Math.abs(A.c - B.c)
-  return (dr + dc === 1)
+    const idx = n - 1;
+    return { r: Math.floor(idx / 5), c: idx % 5 };
+  };
+  const A = pos(a),
+    B = pos(b);
+  const dr = Math.abs(A.r - B.r),
+    dc = Math.abs(A.c - B.c);
+  return dr + dc === 1;
 }

--- a/src/ledger/sync.ts
+++ b/src/ledger/sync.ts
@@ -1,52 +1,72 @@
-import type { HouseCert } from '../certs/houseCert'
-import { getUnsyncedEntries, markSynced } from './localLedger'
-import { bytesToBase64Url } from '../utils/base64'
+import type { HouseCert } from '../certs/houseCert';
+import { getUnsyncedEntries, markSynced } from './localLedger';
+import { bytesToBase64Url } from '../utils/base64';
 
-const encoder = new TextEncoder()
+const encoder = new TextEncoder();
 
-type SyncResult = { ok: true; synced: number } | { ok: false; error: string }
-type SyncChallengeResponse = { nonce: string }
-type SyncCommitRequest = { houseCert: HouseCert; entries: any[]; proof: { nonce: string; sig: string } }
+type SyncResult = { ok: true; synced: number } | { ok: false; error: string };
+type SyncChallengeResponse = { nonce: string };
+type SyncCommitRequest = {
+  houseCert: HouseCert;
+  entries: any[];
+  proof: { nonce: string; sig: string };
+};
 
-export async function syncWithAuthority(houseCert: HouseCert, signer: CryptoKey | null): Promise<SyncResult> {
-  const entries = getUnsyncedEntries()
-  if (entries.length === 0) return { ok: true, synced: 0 }
+export async function syncWithAuthority(
+  houseCert: HouseCert,
+  signer: CryptoKey | null,
+): Promise<SyncResult> {
+  const entries = getUnsyncedEntries();
+  if (entries.length === 0) return { ok: true, synced: 0 };
 
-  const base = (import.meta as any).env?.VITE_AUTH_URL as string | undefined
+  const base = (import.meta as any).env?.VITE_AUTH_URL as string | undefined;
   if (!base) {
     // Dev fallback: mark as synced locally; production should set VITE_AUTH_URL
-    const upto = entries[entries.length - 1].seq
-    markSynced(upto)
-    console.warn('No VITE_AUTH_URL set; marking entries as synced locally (dev mode).')
-    return { ok: true, synced: entries.length }
+    const upto = entries[entries.length - 1].entryId;
+    markSynced(upto);
+    console.warn(
+      'No VITE_AUTH_URL set; marking entries as synced locally (dev mode).',
+    );
+    return { ok: true, synced: entries.length };
   }
 
   try {
-    if (!signer) return { ok: false, error: 'missing signer' }
+    if (!signer) return { ok: false, error: 'missing signer' };
 
-    const root = base.replace(/\/$/, '')
+    const root = base.replace(/\/$/, '');
     const chalRes = await fetch(`${root}/sync/challenge`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ houseCert }),
-    })
-    if (!chalRes.ok) return { ok: false, error: `challenge failed: ${chalRes.status}` }
-    const { nonce } = (await chalRes.json()) as SyncChallengeResponse
-    const data = encoder.encode(nonce)
-    const sigBuf = await crypto.subtle.sign({ name: 'ECDSA', hash: 'SHA-256' }, signer, data)
-    const sig = bytesToBase64Url(new Uint8Array(sigBuf))
-    const commit: SyncCommitRequest = { houseCert, entries, proof: { nonce, sig } }
+    });
+    if (!chalRes.ok)
+      return { ok: false, error: `challenge failed: ${chalRes.status}` };
+    const { nonce } = (await chalRes.json()) as SyncChallengeResponse;
+    const data = encoder.encode(nonce);
+    const sigBuf = await crypto.subtle.sign(
+      { name: 'ECDSA', hash: 'SHA-256' },
+      signer,
+      data,
+    );
+    const sig = bytesToBase64Url(new Uint8Array(sigBuf));
+    const commit: SyncCommitRequest = {
+      houseCert,
+      entries,
+      proof: { nonce, sig },
+    };
     const res = await fetch(`${root}/sync`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify(commit),
-    })
-    if (!res.ok) return { ok: false, error: `sync failed: ${res.status}` }
-    const json = await res.json().catch(() => ({})) as { lastSeq?: number }
-    const lastSeq = json.lastSeq ?? entries[entries.length - 1].seq
-    markSynced(lastSeq)
-    return { ok: true, synced: entries.length }
+    });
+    if (!res.ok) return { ok: false, error: `sync failed: ${res.status}` };
+    const json = (await res.json().catch(() => ({}))) as {
+      lastEntryId?: string;
+    };
+    const lastId = json.lastEntryId ?? entries[entries.length - 1].entryId;
+    markSynced(lastId);
+    return { ok: true, synced: entries.length };
   } catch (e: any) {
-    return { ok: false, error: e?.message || 'network error' }
+    return { ok: false, error: e?.message || 'network error' };
   }
 }


### PR DESCRIPTION
## Summary
- drop seq and roundId from ledger entries; track sync state by entryId
- add session_closed and sync_export checkpoint events with helpers
- pass round identifiers inside appendLedger payloads and sync via entryId

## Testing
- `npm run build`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68bcbd9306c483229eb422824311664e