### PR TITLE
feat(house): log join challenge and admission outcomes

### DIFF
--- a/src/ledger/localLedger.ts
+++ b/src/ledger/localLedger.ts
@@ -7,6 +7,7 @@ export type LedgerEventType =
   | 'receipt_issued'
   | 'join_challenge_issued'
   | 'admission'
+  | 'admission_rejected'
   | 'receipt_spent'
   | 'session_closed'
   | 'sync_export';


### PR DESCRIPTION
## Summary
- record join challenge parameters in ledger
- log admissions and rejection reasons during join responses
- add `admission_rejected` ledger event type

## Testing
- `npm run build`
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bcc0547628832297228914d1d29977