### PR TITLE
fix: remove bet cert type field

### DIFF
--- a/src/__tests__/cert-encoding.test.ts
+++ b/src/__tests__/cert-encoding.test.ts
@@ -1,43 +1,49 @@
-import { describe, it, expect } from 'vitest'
-import { bytesToBase64Url, base64UrlToBytes } from '../utils/base64'
-import { validateHouseCert } from '../certs/houseCert'
-import { verifyBetCert } from '../certs/betCert'
-import { verifyBankReceipt } from '../certs/bankReceipt'
+import { describe, it, expect } from 'vitest';
+import { bytesToBase64Url, base64UrlToBytes } from '../utils/base64';
+import { validateHouseCert } from '../certs/houseCert';
+import { verifyBetCert } from '../certs/betCert';
+import { verifyBankReceipt } from '../certs/bankReceipt';
 
-const encoder = new TextEncoder()
+const encoder = new TextEncoder();
 function subtle() {
-  return globalThis.crypto.subtle
+  return globalThis.crypto.subtle;
 }
 async function genKeyPair() {
-  return subtle().generateKey({ name: 'ECDSA', namedCurve: 'P-256' }, true, ['sign', 'verify'])
+  return subtle().generateKey({ name: 'ECDSA', namedCurve: 'P-256' }, true, [
+    'sign',
+    'verify',
+  ]);
 }
 
 describe('certificate signature encoding utilities', () => {
   it('houseCert roundtrip signature', async () => {
-    const root = await genKeyPair()
-    const house = await genKeyPair()
+    const root = await genKeyPair();
+    const house = await genKeyPair();
     const payload = {
       houseId: 'house-1',
       kid: 'k1',
       housePubKey: await subtle().exportKey('jwk', house.publicKey),
       notBefore: Date.now() - 1000,
       notAfter: Date.now() + 60_000,
-      roles: ['host rounds']
-    }
-    const data = encoder.encode(JSON.stringify(payload))
-    const sigBuf = await subtle().sign({ name: 'ECDSA', hash: 'SHA-256' }, root.privateKey, data)
-    const sigBytes = new Uint8Array(sigBuf)
-    const encoded = bytesToBase64Url(sigBytes)
-    const decoded = base64UrlToBytes(encoded)
-    expect(decoded).toEqual(sigBytes)
-    const cert = { payload, signature: encoded }
-    expect(await validateHouseCert(cert, root.publicKey)).toBe(true)
-  })
+      roles: ['host rounds'],
+    };
+    const data = encoder.encode(JSON.stringify(payload));
+    const sigBuf = await subtle().sign(
+      { name: 'ECDSA', hash: 'SHA-256' },
+      root.privateKey,
+      data,
+    );
+    const sigBytes = new Uint8Array(sigBuf);
+    const encoded = bytesToBase64Url(sigBytes);
+    const decoded = base64UrlToBytes(encoded);
+    expect(decoded).toEqual(sigBytes);
+    const cert = { payload, signature: encoded };
+    expect(await validateHouseCert(cert, root.publicKey)).toBe(true);
+  });
 
   it('betCert roundtrip signature', async () => {
-    const house = await genKeyPair()
+    const house = await genKeyPair();
     const payload = {
-      type: 'bet-cert' as const,
       houseId: 'house-1',
       roundId: 'r1',
       seat: 1,
@@ -46,37 +52,44 @@ describe('certificate signature encoding utilities', () => {
       issuedAt: Date.now() - 1000,
       exp: Date.now() + 60_000,
       betHash: 'hash',
-    }
-    const data = encoder.encode(JSON.stringify(payload))
-    const sigBuf = await subtle().sign({ name: 'ECDSA', hash: 'SHA-256' }, house.privateKey, data)
-    const sigBytes = new Uint8Array(sigBuf)
-    const encoded = bytesToBase64Url(sigBytes)
-    const decoded = base64UrlToBytes(encoded)
-    expect(decoded).toEqual(sigBytes)
-    const cert = { ...payload, sig: encoded }
-    expect(await verifyBetCert(cert, house.publicKey)).toBe(true)
-  })
+    };
+    const data = encoder.encode(JSON.stringify(payload));
+    const sigBuf = await subtle().sign(
+      { name: 'ECDSA', hash: 'SHA-256' },
+      house.privateKey,
+      data,
+    );
+    const sigBytes = new Uint8Array(sigBuf);
+    const encoded = bytesToBase64Url(sigBytes);
+    const decoded = base64UrlToBytes(encoded);
+    expect(decoded).toEqual(sigBytes);
+    const cert = { ...payload, sig: encoded };
+    expect(await verifyBetCert(cert, house.publicKey)).toBe(true);
+  });
 
-    it('bankReceipt roundtrip signature', async () => {
-      const house = await genKeyPair()
-      const payload = {
-        type: 'bank-receipt' as const,
-        houseId: 'house-1',
-        playerUidThumbprint: 'p1',
-        receiptId: 'rec1',
-        kind: 'REBUY' as const,
-        amount: 100,
-        issuedAt: Date.now() - 1000,
-        exp: Date.now() + 60_000,
-      }
-      const data = encoder.encode(JSON.stringify(payload))
-      const sigBuf = await subtle().sign({ name: 'ECDSA', hash: 'SHA-256' }, house.privateKey, data)
-      const sigBytes = new Uint8Array(sigBuf)
-      const encoded = bytesToBase64Url(sigBytes)
-      const decoded = base64UrlToBytes(encoded)
-      expect(decoded).toEqual(sigBytes)
-      const receipt = { ...payload, sig: encoded }
-      expect(await verifyBankReceipt(receipt, house.publicKey)).toBe(true)
-    })
-})
-
+  it('bankReceipt roundtrip signature', async () => {
+    const house = await genKeyPair();
+    const payload = {
+      type: 'bank-receipt' as const,
+      houseId: 'house-1',
+      playerUidThumbprint: 'p1',
+      receiptId: 'rec1',
+      kind: 'REBUY' as const,
+      amount: 100,
+      issuedAt: Date.now() - 1000,
+      exp: Date.now() + 60_000,
+    };
+    const data = encoder.encode(JSON.stringify(payload));
+    const sigBuf = await subtle().sign(
+      { name: 'ECDSA', hash: 'SHA-256' },
+      house.privateKey,
+      data,
+    );
+    const sigBytes = new Uint8Array(sigBuf);
+    const encoded = bytesToBase64Url(sigBytes);
+    const decoded = base64UrlToBytes(encoded);
+    expect(decoded).toEqual(sigBytes);
+    const receipt = { ...payload, sig: encoded };
+    expect(await verifyBankReceipt(receipt, house.publicKey)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- drop `type` from BetCert payload and canonicalize signing
- adjust cert encoding test for new BetCert payload

## Testing
- `npm run build`
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bcc63dfd808322b96b2e8adb2785a1