### PR TITLE
feat: propagate bankRef in bet certs

### DIFF
--- a/src/House.tsx
+++ b/src/House.tsx
@@ -134,6 +134,7 @@ export default function House() {
         certId: c.certId,
         betHash: c.betHash,
         exp: c.exp,
+        bankRef: c.bankRef,
       });
     }
   };
@@ -413,6 +414,7 @@ export default function House() {
                       bets: [],
                       pool: PER_ROUND_POOL,
                       bank: 0,
+                      bankRef: resp.bankRef,
                     },
                   ].sort((a, b) => a.seat - b.seat),
                 );

--- a/src/__tests__/round.test.ts
+++ b/src/__tests__/round.test.ts
@@ -23,11 +23,13 @@ describe('round locking', () => {
         bets: [{ id: 'b1', type: 'single', selection: [1], amount: 1 }],
         pool: 0,
         bank: 0,
+        bankRef: 'bank-1',
       },
       { seat: 2, uid: 'p2', name: 'P2', bets: [], pool: 0, bank: 0 },
     ];
     const certs = await lockRound(players, house.privateKey, 'r1', 'house-1');
     expect(certs).toHaveLength(2);
     expect(certs[0].seat).toBe(1);
+    expect(certs[0].bankRef).toBe('bank-1');
   });
 });

--- a/src/round.ts
+++ b/src/round.ts
@@ -42,6 +42,7 @@ export async function lockRound(
         betHash,
         issuedAt: now,
         exp: now + 5 * 60 * 1000,
+        bankRef: p.bankRef,
       },
       houseKey,
     );

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,4 +18,5 @@ export interface Player {
   bets: Bet[];
   pool: number;
   bank: number;
+  bankRef?: string;
 }


### PR DESCRIPTION
## Summary
- track optional bank reference on players
- propagate bankRef into bet certificates and ledger entries

## Testing
- `npm run build`
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bcc905db2c83229975ede388ed8dc8