### PR TITLE
feat(betting): allow choosing receipt kind

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,6 +25,8 @@ export default function App() {
     covered,
     active,
     setActiveId,
+    receiptKind,
+    setReceiptKind,
     maxForActive,
     undoLast,
     clearBets,
@@ -92,6 +94,8 @@ export default function App() {
         setEnteredRoll={setEnteredRoll}
         settleRound={settleRound}
         newRound={newRound}
+        receiptKind={receiptKind}
+        setReceiptKind={setReceiptKind}
       />
 
       <BetBoard

--- a/src/__tests__/receipts.test.ts
+++ b/src/__tests__/receipts.test.ts
@@ -1,24 +1,43 @@
-import { describe, it, expect } from 'vitest'
-import { issueReceiptsForWinners } from '../receipts'
+import { describe, it, expect } from 'vitest';
+import { issueReceiptsForWinners } from '../receipts';
 
-function subtle() { return globalThis.crypto.subtle }
-async function genKeyPair() { return subtle().generateKey({ name: 'ECDSA', namedCurve: 'P-256' }, true, ['sign','verify']) }
+function subtle() {
+  return globalThis.crypto.subtle;
+}
+async function genKeyPair() {
+  return subtle().generateKey({ name: 'ECDSA', namedCurve: 'P-256' }, true, [
+    'sign',
+    'verify',
+  ]);
+}
 
 describe('bank receipts', () => {
   it('issues receipts for winners with correct values and references', async () => {
-    const house = await genKeyPair()
-      const winners = [
-        { player: 1, playerUidThumbprint: 'p1', amount: 5, kind: 'REBUY' as const },
-        { player: 2, playerUidThumbprint: 'p2', amount: 3, kind: 'REBUY' as const },
-      ]
-      const receipts = await issueReceiptsForWinners(
-        winners,
-        'round1',
-        'house-1',
-        (house as CryptoKeyPair).privateKey
-      )
-      expect(receipts).toHaveLength(2)
-      expect(receipts[0].receipt.amount).toBe(5)
-      expect(receipts[1].receipt.amount).toBe(3)
-    })
-  })
+    const house = await genKeyPair();
+    const winners = [
+      {
+        player: 1,
+        playerUidThumbprint: 'p1',
+        amount: 5,
+        kind: 'REBUY' as const,
+      },
+      {
+        player: 2,
+        playerUidThumbprint: 'p2',
+        amount: 3,
+        kind: 'REDEEM' as const,
+      },
+    ];
+    const receipts = await issueReceiptsForWinners(
+      winners,
+      'round1',
+      'house-1',
+      (house as CryptoKeyPair).privateKey,
+    );
+    expect(receipts).toHaveLength(2);
+    expect(receipts[0].receipt.amount).toBe(5);
+    expect(receipts[1].receipt.amount).toBe(3);
+    expect(receipts[0].receipt.kind).toBe('REBUY');
+    expect(receipts[1].receipt.kind).toBe('REDEEM');
+  });
+});

--- a/src/components/BetControls.tsx
+++ b/src/components/BetControls.tsx
@@ -19,6 +19,8 @@ interface Props {
   setEnteredRoll: (n: number | '') => void;
   settleRound: () => void;
   newRound: () => void;
+  receiptKind: 'REDEEM' | 'REBUY';
+  setReceiptKind: (k: 'REDEEM' | 'REBUY') => void;
 }
 
 export function BetControls({
@@ -37,6 +39,8 @@ export function BetControls({
   setEnteredRoll,
   settleRound,
   newRound,
+  receiptKind,
+  setReceiptKind,
 }: Props) {
   const canPlaceActive =
     roundState === 'open' && amount >= minBet && amount <= active.pool;
@@ -103,6 +107,20 @@ export function BetControls({
         <button onClick={lockRound} disabled={roundState !== 'open'}>
           Lock Bets
         </button>
+        <div className="receipt-kind">
+          <label>
+            Receipt:
+            <select
+              value={receiptKind}
+              onChange={(e) =>
+                setReceiptKind(e.target.value as 'REDEEM' | 'REBUY')
+              }
+            >
+              <option value="REBUY">Rebuy</option>
+              <option value="REDEEM">Redeem</option>
+            </select>
+          </label>
+        </div>
         <div className="manual-roll">
           <input
             type="number"

--- a/src/hooks/useBetting.ts
+++ b/src/hooks/useBetting.ts
@@ -57,6 +57,14 @@ export function useBetting() {
     setAmount((a) => clampInt(a, MIN_BET, maxForActive));
   }, [active?.pool]);
 
+  const [receiptKinds, setReceiptKinds] = React.useState<
+    Record<number, 'REDEEM' | 'REBUY'>
+  >({});
+  const receiptKind = active ? receiptKinds[active.seat] || 'REBUY' : 'REBUY';
+  const setReceiptKind = (k: 'REDEEM' | 'REBUY') => {
+    if (active) setReceiptKinds((prev) => ({ ...prev, [active.seat]: k }));
+  };
+
   const canPlace = (p: Player) =>
     roundState === 'open' && amount >= MIN_BET && amount <= p.pool;
 
@@ -176,7 +184,7 @@ export function useBetting() {
           player: p.seat,
           playerUidThumbprint: p.uid,
           amount: deltas[p.seat],
-          kind: 'REBUY' as const,
+          kind: receiptKinds[p.seat] || 'REBUY',
         }));
       const roundId = String(stats.rounds + 1);
       const houseId = 'house-1';
@@ -195,6 +203,7 @@ export function useBetting() {
           playerUidThumbprint: w.playerUidThumbprint,
           amount: w.amount,
           receiptId: rec?.receipt.receiptId,
+          kind: w.kind,
         });
       }
     }
@@ -236,6 +245,8 @@ export function useBetting() {
     active,
     activeId,
     setActiveId,
+    receiptKind,
+    setReceiptKind,
     maxForActive,
     canPlace,
     addBetFor,


### PR DESCRIPTION
## Summary
- add per-player receipt preference for REDEEM or REBUY
- expose receipt kind selector in betting controls
- record receipt kind on issuance and in ledger

## Testing
- `npm run build`
- `npm test -- --run`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68bccb36f248832285722058a89641a1