### PR TITLE
feat(join): encode house cert and simplify join response

### DIFF
--- a/src/__tests__/JoinScannerFallback.test.tsx
+++ b/src/__tests__/JoinScannerFallback.test.tsx
@@ -70,7 +70,6 @@ describe('JoinScanner fallback', () => {
 
     const { container } = render(
       <JoinScanner
-        alias="p1"
         playerKeys={player as CryptoKeyPair}
         rootKey={root.publicKey}
         onResponse={onResponse}

--- a/src/components/JoinScanner.tsx
+++ b/src/components/JoinScanner.tsx
@@ -8,11 +8,9 @@ import {
 } from '../join';
 
 interface JoinScannerProps {
-  alias: string;
   playerKeys: CryptoKeyPair;
   rootKey: CryptoKey;
   seat?: number;
-  bankRef?: string;
   onResponse: (resp: JoinResponse) => void;
   onResponseEx?: (
     resp: JoinResponse,
@@ -21,11 +19,9 @@ interface JoinScannerProps {
 }
 
 export default function JoinScanner({
-  alias,
   playerKeys,
   rootKey,
   seat = 0,
-  bankRef,
   onResponse,
   onResponseEx,
 }: JoinScannerProps) {
@@ -111,11 +107,9 @@ export default function JoinScanner({
         return;
       }
       const resp = await createJoinResponse(
-        alias,
         challenge,
         playerKeys,
         seat,
-        bankRef,
       );
       onResponse(resp);
       if (typeof onResponseEx === 'function') {

--- a/src/hooks/useJoin.ts
+++ b/src/hooks/useJoin.ts
@@ -63,7 +63,6 @@ export function useJoin() {
   const joinScannerProps = React.useMemo(() => {
     if (!playerKeys || !rootKey) return null;
     return {
-      alias: playerId || 'Player',
       playerKeys,
       rootKey,
       onResponse: async (resp: JoinResponse) => {
@@ -94,7 +93,7 @@ export function useJoin() {
         setJoinTotp(code);
       },
     };
-  }, [playerId, playerKeys, playerSecret, rootKey]);
+  }, [playerKeys, playerSecret, rootKey]);
 
   const showPairingCode = React.useCallback(async () => {
     if (!playerSecret) return;


### PR DESCRIPTION
## Summary
- encode house certificate as base64 in join challenges and decode on parse/validation
- drop alias and bankRef from join response, updating join flow components and tests

## Testing
- `npm run build`
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bcccef08748322b1475e84a20efdca