### PR TITLE
feat: load root public key and seed house cert ledger

### DIFF
--- a/src/certs/authorizedHouseCertLedger.ts
+++ b/src/certs/authorizedHouseCertLedger.ts
@@ -1,26 +1,28 @@
-import { HouseCert } from './houseCert'
+import { HouseCert } from './houseCert';
+import rootPublicKeyJwk from '../../.sec/root_public_jwk.json';
 
 export interface AuthorizedHouseCertLedgerEntry {
-  houseId: string
-  kid: string
-  signature: string
+  houseId: string;
+  kid: string;
+  signature: string;
 }
 
-export const authorizedHouseCertLedger: AuthorizedHouseCertLedgerEntry[] = []
+export const authorizedHouseCertLedger: AuthorizedHouseCertLedgerEntry[] = [
+  {
+    houseId: 'house-1',
+    kid: 'k1',
+    signature:
+      'OJ2s-h_XV1ryLjfZdr41msgSw9umYKHpHPKlHn9KbRCOq75eht4DnuxauDgKVOyC3Fela_KWCRE1WxDFoVMj-Q',
+  },
+];
 
-export const houseCertRootPublicKeyJwk: JsonWebKey = {
-  kty: 'EC',
-  crv: 'P-256',
-  x: 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
-  y: 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
-  ext: true,
-}
+export const houseCertRootPublicKeyJwk = rootPublicKeyJwk as JsonWebKey;
 
 export function isAuthorizedHouseCert(cert: HouseCert): boolean {
   return authorizedHouseCertLedger.some(
-    entry =>
+    (entry) =>
       entry.houseId === cert.payload.houseId &&
       entry.kid === cert.payload.kid &&
-      entry.signature === cert.signature
-  )
+      entry.signature === cert.signature,
+  );
 }


### PR DESCRIPTION
## Summary
- import root public key JWK from `.sec` for house cert verification
- seed authorized house certificate ledger with first issued cert entry

## Testing
- `npm run build`
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bd92a9d7e083229c44281394c35375