### PR TITLE
feat(worker): implement ES256 signing and JWKS

### DIFF
--- a/docs/houseCert.md
+++ b/docs/houseCert.md
@@ -1,31 +1,35 @@
-HouseCert Cloudflare Worker
-===========================
+# HouseCert Cloudflare Worker
 
 Purpose
- - Issues round-bound, expiring Bet Certificates signed with ECDSA-P256.
- - Exposes health and JWKS endpoints for verification.
+
+- Issues round-bound, expiring Bet Certificates signed with ECDSA-P256.
+- Exposes health and JWKS endpoints for verification.
 
 Paths
- - `workers/houseCert/src/index.ts`
- - `workers/houseCert/wrangler.toml`
+
+- `workers/houseCert/src/index.ts`
+- `workers/houseCert/wrangler.toml`
 
 Endpoints
- - `GET /health` — Basic readiness probe.
- - `GET /.well-known/jwks.json` — JWKS for verifying ES256 signatures (optional placeholder).
- - `POST /houseCert` — Mint a Bet Cert (currently 501 placeholder).
+
+- `GET /health` — Basic readiness probe.
+- `GET /.well-known/jwks.json` — JWKS derived from the signing key.
+- `POST /houseCert` — Mint a short‑lived, round‑bound Bet Cert (JWT).
 
 Local Dev
- - Use your logged-in Wrangler: `npm run cf:dev:house`
+
+- Use your logged-in Wrangler: `npm run cf:dev:house`
 
 Deploy
- - `npm run cf:deploy:house`
+
+- `npm run cf:deploy:house`
 
 Config
- - Non-secret vars: set in `wrangler.toml` `[vars]` (e.g., `HOUSE_PUB_KEY_PEM`).
- - Secrets: `wrangler secret put HOUSE_PRIV_KEY_PEM` (PKCS#8 PEM for P-256).
- - Account: Wrangler can infer from your login; set `account_id` in `wrangler.toml` if desired.
+
+- Secrets: `wrangler secret put HOUSE_PRIV_KEY_PEM` (PKCS#8 PEM for P‑256).
+- Account: Wrangler can infer from your login; set `account_id` in `wrangler.toml` if desired.
 
 Notes
- - Do not commit secrets. Use `wrangler secret` for private keys.
- - Replace the JWKS placeholder with a computed key from your public key.
 
+- Do not commit secrets. Use `wrangler secret` for private keys.
+- JWKS is computed from the secret signing key; no public key vars required.

--- a/workers/houseCert/src/index.test.ts
+++ b/workers/houseCert/src/index.test.ts
@@ -1,0 +1,57 @@
+import {
+  importPrivateKey,
+  derivePublicJwk,
+  signJwt,
+  base64UrlDecode,
+} from './index';
+import { expect, test } from 'vitest';
+
+const decoder = new TextDecoder();
+
+function decodePayload(segment: string) {
+  return JSON.parse(decoder.decode(base64UrlDecode(segment)));
+}
+
+function decodeHeader(segment: string) {
+  return JSON.parse(Buffer.from(segment, 'base64url').toString('utf8'));
+}
+
+async function makeTestPem() {
+  const { privateKey } = await crypto.subtle.generateKey(
+    { name: 'ECDSA', namedCurve: 'P-256' },
+    true,
+    ['sign', 'verify'],
+  );
+  const pkcs8 = await crypto.subtle.exportKey('pkcs8', privateKey);
+  const b64 = Buffer.from(pkcs8).toString('base64');
+  const lines = b64.match(/.{1,64}/g) || [];
+  return `-----BEGIN PRIVATE KEY-----\n${lines.join('\n')}\n-----END PRIVATE KEY-----`;
+}
+
+test('signJwt issues verifiable ES256 token', async () => {
+  const privPem = await makeTestPem();
+  const pk = await importPrivateKey(privPem);
+  const { jwk } = await derivePublicJwk(pk);
+  const token = await signJwt(pk, jwk.kid!, { roundId: 'r1', iat: 0, exp: 1 });
+  const [h, p, s] = token.split('.');
+
+  expect(decodePayload(p).roundId).toBe('r1');
+  expect(decodeHeader(h).alg).toBe('ES256');
+
+  const verifyKey = await crypto.subtle.importKey(
+    'jwk',
+    jwk,
+    { name: 'ECDSA', namedCurve: 'P-256' },
+    false,
+    ['verify'],
+  );
+  const data = new TextEncoder().encode(`${h}.${p}`);
+  const sig = base64UrlDecode(s);
+  const ok = await crypto.subtle.verify(
+    { name: 'ECDSA', hash: 'SHA-256' },
+    verifyKey,
+    sig,
+    data,
+  );
+  expect(ok).toBe(true);
+});

--- a/workers/houseCert/src/index.ts
+++ b/workers/houseCert/src/index.ts
@@ -1,31 +1,142 @@
 export interface Env {
-  // Secrets (set via `wrangler secret put`)
-  // HOUSE_PRIV_KEY_PEM: string; // PKCS#8 PEM for ECDSA-P256
+  /** PKCS#8 PEM for ECDSA-P256 (secret via `wrangler secret put`) */
+  HOUSE_PRIV_KEY_PEM: string;
 
-  // Optional non-secret config
-  HOUSE_PUB_KEY_PEM?: string; // Public key PEM for JWKS endpoint
-
-  // KV for replay protection / join tokens
+  /** KV for join-token usage and basic replay protection */
   CERT_LEDGER: KVNamespace;
 }
 
-type Json = Record<string, unknown> | unknown[] | string | number | boolean | null;
+type Json =
+  | Record<string, unknown>
+  | unknown[]
+  | string
+  | number
+  | boolean
+  | null;
+
+const encoder = new TextEncoder();
+
+function base64UrlEncode(data: ArrayBuffer | Uint8Array | string): string {
+  let bytes: Uint8Array;
+  if (typeof data === 'string') {
+    bytes = encoder.encode(data);
+  } else {
+    bytes = data instanceof Uint8Array ? data : new Uint8Array(data);
+  }
+  let binary = '';
+  for (const b of bytes) binary += String.fromCharCode(b);
+  return btoa(binary)
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+}
+
+export function base64UrlDecode(str: string): Uint8Array {
+  const pad = str.length % 4;
+  const b64 =
+    str.replace(/-/g, '+').replace(/_/g, '/') +
+    (pad ? '='.repeat(4 - pad) : '');
+  const bin = atob(b64);
+  const bytes = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+  return bytes;
+}
+
+function pemToArrayBuffer(pem: string): Uint8Array {
+  const b64 = pem.replace(/-----[^-]+-----/g, '').replace(/\s+/g, '');
+  return base64UrlDecode(b64);
+}
+
+export async function importPrivateKey(pem: string): Promise<CryptoKey> {
+  return crypto.subtle.importKey(
+    'pkcs8',
+    pemToArrayBuffer(pem),
+    { name: 'ECDSA', namedCurve: 'P-256' },
+    true,
+    ['sign'],
+  );
+}
+
+export async function derivePublicJwk(privateKey: CryptoKey): Promise<{
+  jwk: JsonWebKey & { kid: string };
+}> {
+  const jwk = (await crypto.subtle.exportKey('jwk', privateKey)) as JsonWebKey;
+  if (!jwk.x || !jwk.y) throw new Error('invalid key');
+  const publicJwk: JsonWebKey & { kid: string } = {
+    kty: 'EC',
+    crv: 'P-256',
+    x: jwk.x,
+    y: jwk.y,
+    use: 'sig',
+    alg: 'ES256',
+    kid: '', // filled below
+  };
+  const pubKey = await crypto.subtle.importKey(
+    'jwk',
+    publicJwk,
+    { name: 'ECDSA', namedCurve: 'P-256' },
+    true,
+    ['verify'],
+  );
+  const spki = await crypto.subtle.exportKey('spki', pubKey);
+  const hash = await crypto.subtle.digest('SHA-256', spki);
+  publicJwk.kid = base64UrlEncode(hash).slice(0, 32);
+  return { jwk: publicJwk };
+}
+
+async function signJwt(
+  privateKey: CryptoKey,
+  kid: string,
+  payload: Record<string, unknown>,
+): Promise<string> {
+  const header = { alg: 'ES256', typ: 'JWT', kid };
+  const encHeader = base64UrlEncode(JSON.stringify(header));
+  const encPayload = base64UrlEncode(JSON.stringify(payload));
+  const data = encoder.encode(`${encHeader}.${encPayload}`);
+  const signature = await crypto.subtle.sign(
+    { name: 'ECDSA', hash: 'SHA-256' },
+    privateKey,
+    data,
+  );
+  const encSig = base64UrlEncode(signature);
+  return `${encHeader}.${encPayload}.${encSig}`;
+}
+
+export { signJwt };
+
+let materialPromise: Promise<{
+  privateKey: CryptoKey;
+  publicJwk: JsonWebKey & { kid: string };
+}> | null = null;
+
+async function getSigningMaterial(env: Env) {
+  if (!materialPromise) {
+    materialPromise = (async () => {
+      if (!env.HOUSE_PRIV_KEY_PEM)
+        throw new Error('HOUSE_PRIV_KEY_PEM missing');
+      const privateKey = await importPrivateKey(env.HOUSE_PRIV_KEY_PEM);
+      const { jwk } = await derivePublicJwk(privateKey);
+      return { privateKey, publicJwk: jwk };
+    })();
+  }
+  return materialPromise;
+}
 
 function json(data: Json, init?: ResponseInit) {
-  const body = typeof data === "string" ? data : JSON.stringify(data);
+  const body = typeof data === 'string' ? data : JSON.stringify(data);
   return new Response(body, {
-    headers: { "content-type": "application/json; charset=utf-8" },
+    headers: { 'content-type': 'application/json; charset=utf-8' },
     ...init,
   });
 }
 
 async function handleJwks(env: Env) {
-  const pem = env.HOUSE_PUB_KEY_PEM;
-  if (!pem) return json({ error: "JWKS not configured" }, { status: 404 });
-
-  // Minimal JWKS from PEM; in production, precompute and store as VAR
-  // Here we return a placeholder to avoid blocking initial wiring.
-  return json({ keys: [{ kty: "EC", crv: "P-256", use: "sig", alg: "ES256", kid: "house-p256", x: "", y: "" }] });
+  try {
+    const { publicJwk } = await getSigningMaterial(env);
+    return json({ keys: [publicJwk] });
+  } catch {
+    return json({ error: 'JWKS not configured' }, { status: 404 });
+  }
 }
 
 async function handleHealth() {
@@ -33,30 +144,41 @@ async function handleHealth() {
 }
 
 async function handleHouseCert(req: Request, env: Env) {
-  // Placeholder endpoint. Implement ECDSA-P256 signing of a short-lived, round-bound Bet Cert.
-  // Expected input example: { joinToken: string, roundId: string, payload?: object }
-  // Validate joinToken (short-lived, one-time), check replay via ledger, then sign payload.
   try {
-    const body = (await req.json().catch(() => ({}))) as Record<string, unknown>;
-    const joinToken = typeof body["joinToken"] === "string" ? (body["joinToken"] as string) : undefined;
-    const roundId = typeof body["roundId"] === "string" ? (body["roundId"] as string) : undefined;
+    const body = (await req.json().catch(() => ({}))) as Record<
+      string,
+      unknown
+    >;
+    const joinToken =
+      typeof body['joinToken'] === 'string'
+        ? (body['joinToken'] as string)
+        : undefined;
+    const roundId =
+      typeof body['roundId'] === 'string'
+        ? (body['roundId'] as string)
+        : undefined;
 
     if (!joinToken || !roundId) {
-      return json({ error: "joinToken and roundId required" }, { status: 400 });
+      return json({ error: 'joinToken and roundId required' }, { status: 400 });
     }
 
-    // Basic best-effort replay guard using KV (non-atomic; for strict protection use DO/D1)
     const key = `jt:${roundId}:${joinToken}`;
     const seen = await env.CERT_LEDGER.get(key);
     if (seen) {
-      return json({ error: "replay detected" }, { status: 409 });
+      return json({ error: 'replay detected' }, { status: 409 });
     }
-    await env.CERT_LEDGER.put(key, "1", { expirationTtl: 600 });
+    await env.CERT_LEDGER.put(key, '1', { expirationTtl: 600 });
 
-    // Signing not yet implemented
-    return json({ error: "Not implemented yet", kvRecorded: true }, { status: 501 });
+    const { privateKey, publicJwk } = await getSigningMaterial(env);
+    const now = Math.floor(Date.now() / 1000);
+    const payload = { roundId, iat: now, exp: now + 60 };
+    const token = await signJwt(privateKey, publicJwk.kid!, payload);
+    return json({ houseCert: token });
   } catch (e) {
-    return json({ error: "invalid request", detail: String(e) }, { status: 400 });
+    return json(
+      { error: 'invalid request', detail: String(e) },
+      { status: 400 },
+    );
   }
 }
 
@@ -65,10 +187,12 @@ export default {
     const url = new URL(request.url);
     const path = url.pathname;
 
-    if (request.method === "GET" && path === "/health") return handleHealth();
-    if (request.method === "GET" && path === "/.well-known/jwks.json") return handleJwks(env);
-    if (request.method === "POST" && path === "/houseCert") return handleHouseCert(request, env);
+    if (request.method === 'GET' && path === '/health') return handleHealth();
+    if (request.method === 'GET' && path === '/.well-known/jwks.json')
+      return handleJwks(env);
+    if (request.method === 'POST' && path === '/houseCert')
+      return handleHouseCert(request, env);
 
-    return json({ error: "Not found" }, { status: 404 });
+    return json({ error: 'Not found' }, { status: 404 });
   },
 };

--- a/workers/houseCert/wrangler.toml
+++ b/workers/houseCert/wrangler.toml
@@ -14,3 +14,9 @@ compatibility_date = "2024-09-10"
 # Secrets are set with `wrangler secret put NAME` and not stored in code.
 # HOUSE_PRIV_KEY_PEM (secret) should be set before deploying.
 
+[[kv_namespaces]]
+# KV namespace for join-token usage and basic replay protection
+binding = "CERT_LEDGER"
+id = "db2b30f346794573a54f42225cc94669"
+# preview_id can be set to a dev KV namespace to avoid writing to prod during `wrangler dev`.
+# preview_id = "<your-dev-namespace-id>"

--- a/workers/houseCert/wrangler.toml
+++ b/workers/houseCert/wrangler.toml
@@ -8,8 +8,7 @@ compatibility_date = "2024-09-10"
 # account_id = "" # e.g., 6bbfd1f7f411d4a625d32beed6a766b9 (non-secret)
 
 [vars]
-# Optional: Provide a precomputed JWKS or public key PEM via vars for /.well-known/jwks.json
-# HOUSE_PUB_KEY_PEM = "-----BEGIN PUBLIC KEY-----\n...\n-----END PUBLIC KEY-----\n"
+# No vars required; JWKS is derived from HOUSE_PRIV_KEY_PEM.
 
 # Secrets are set with `wrangler secret put NAME` and not stored in code.
 # HOUSE_PRIV_KEY_PEM (secret) should be set before deploying.

--- a/workers/houseCert/wrangler.toml
+++ b/workers/houseCert/wrangler.toml
@@ -18,5 +18,5 @@ compatibility_date = "2024-09-10"
 # KV namespace for join-token usage and basic replay protection
 binding = "CERT_LEDGER"
 id = "db2b30f346794573a54f42225cc94669"
-# preview_id can be set to a dev KV namespace to avoid writing to prod during `wrangler dev`.
-# preview_id = "<your-dev-namespace-id>"
+# Use dev KV namespace when running `wrangler dev`
+preview_id = "378e25f7c27f4e718d851cb14b7a6f7a"


### PR DESCRIPTION
## Summary
- derive JWKS from `HOUSE_PRIV_KEY_PEM` and expose real `/\.well-known/jwks.json`
- sign short-lived round certificates via ES256 in `/houseCert`
- add unit test for signing flow

## Testing
- `npm run build`
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c2016fbc488322bd2ede3289d13751